### PR TITLE
Namen für group und static_text

### DIFF
--- a/docs/qppe.yaml
+++ b/docs/qppe.yaml
@@ -842,10 +842,12 @@ components:
           enum: [ static_text ]
         label:
           $ref: "#/components/schemas/FormLabel"
+        name:
+          $ref: "#/components/schemas/FormName"
         text:
           type: string
           description: Static text to display
-      required: [ kind, label, text ]
+      required: [ kind, label, name, text ]
 
     TextInputElement:
       type: object
@@ -993,12 +995,14 @@ components:
           enum: [ group ]
         label:
           $ref: "#/components/schemas/FormLabel"
+        name:
+          $ref: "#/components/schemas/FormName"
         elements:
           type: array
           items:
             $ref: "#/components/schemas/FormElement"
           minItems: 1
-      required: [ kind, label, elements, ]
+      required: [ kind, label, name, elements, ]
 
     FormElement:
       oneOf:


### PR DESCRIPTION
Für `static_text` wie besprochen, füge ich auch gleich zur SDK hinzu.
`group` hat in der SDK einen Namen, das scheine ich beim schreiben der API-Spec vergessen zu haben.