### PR TITLE
refactor: use questionpy-common package

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -16,7 +16,7 @@ multidict = ">=4.5,<7.0"
 yarl = ">=1.0,<2.0"
 
 [package.extras]
-speedups = ["aiodns", "brotli", "cchardet"]
+speedups = ["Brotli", "aiodns", "cchardet"]
 
 [[package]]
 name = "aiosignal"
@@ -115,7 +115,7 @@ graph = ["objgraph (>=1.7.2)"]
 name = "faker"
 version = "14.2.0"
 description = "Faker is a Python package that generates fake data for you."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -293,7 +293,7 @@ email = ["email-validator (>=1.0.3)"]
 name = "pydantic-factories"
 version = "1.6.2"
 description = "Mock data generation for pydantic based models"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7,<4.0"
 
@@ -437,7 +437,7 @@ pytest = ">=4.2.1"
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 
@@ -445,10 +445,29 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 six = ">=1.5"
 
 [[package]]
+name = "questionpy-common"
+version = "0.1.0"
+description = "Common classes and functions for QuestionPy"
+category = "main"
+optional = false
+python-versions = "^3.9"
+develop = false
+
+[package.dependencies]
+pydantic = "^1.9.1"
+pydantic-factories = "^1.6.2"
+
+[package.source]
+type = "git"
+url = "https://github.com/questionpy-org/questionpy-common.git"
+reference = "7bbc4e4bacf9a7d9c85be2556faa16d476bbd307"
+resolved_reference = "7bbc4e4bacf9a7d9c85be2556faa16d476bbd307"
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -488,7 +507,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 name = "xeger"
 version = "0.3.5"
 description = "A library for generating random strings from a valid regular expression."
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -507,7 +526,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "2e428998bfefcec9d72de7dcbd1827e43bc45773cfd3d9d8e81135333604ed8a"
+content-hash = "97329eb1e0111d634276748955850efb50a36cb4d822ab6f217ffc52dd14253e"
 
 [metadata.files]
 aiohttp = [
@@ -994,6 +1013,7 @@ python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
 ]
+questionpy-common = []
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ version = "0.1.0"
 python = "^3.9"
 aiohttp = "^3.8.1"
 pydantic = "^1.9.1"
+questionpy-common = {git = "https://github.com/questionpy-org/questionpy-common.git", rev = "7bbc4e4bacf9a7d9c85be2556faa16d476bbd307"}
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.14.5"

--- a/questionpy_server/api/models.py
+++ b/questionpy_server/api/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from enum import Enum
-from typing import Annotated, Any, Dict, List, Optional, Union, Literal
+from typing import Annotated, Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field, FilePath, HttpUrl, Json
 
@@ -192,82 +192,3 @@ class QuestionStateMigrationError(BaseModel):
 
     code: Code
     reason: Optional[str]
-
-
-class _Labelled(BaseModel):
-    label: str
-
-
-class _Named(BaseModel):
-    name: str
-
-
-class StaticTextElement(_Labelled):
-    kind: Literal["static_text"] = "static_text"
-    text: str
-
-
-class TextInputElement(_Labelled, _Named):
-    kind: Literal["input"] = "input"
-    required: bool = False
-    default: Optional[str] = None
-    placeholder: Optional[str] = None
-
-
-class CheckboxElement(_Named):
-    kind: Literal["checkbox"] = "checkbox"
-    left_label: Optional[str] = None
-    right_label: Optional[str] = None
-    required: bool = False
-    selected: bool = False
-
-
-class CheckboxGroupElement(BaseModel):
-    kind: Literal["checkbox_group"] = "checkbox_group"
-    checkboxes: List[CheckboxElement]
-
-
-class Option(BaseModel):
-    label: str
-    value: str
-    selected: bool = False
-
-
-class RadioGroupElement(_Labelled, _Named):
-    kind: Literal["radio_group"] = "radio_group"
-    options: List[Option]
-    required: bool = False
-
-
-class SelectElement(_Labelled, _Named):
-    kind: Literal["select"] = "select"
-    multiple: bool = False
-    options: List[Option]
-    required: bool = False
-
-
-class HiddenElement(_Named):
-    kind: Literal["hidden"] = "hidden"
-    value: str
-
-
-class GroupElement(_Labelled, _Named):
-    kind: Literal["group"] = "group"
-    elements: List["FormElement"]
-
-
-class FormElement(BaseModel):
-    __root__: Union[
-            StaticTextElement, TextInputElement, CheckboxElement, CheckboxGroupElement,
-            RadioGroupElement, SelectElement, HiddenElement, GroupElement
-        ]
-
-
-class FormSection(BaseModel):
-    header: str
-    elements: List[FormElement] = []
-
-
-class Form(BaseModel):
-    general: List[FormElement] = []
-    sections: List[FormSection] = []

--- a/questionpy_server/api/routes.py
+++ b/questionpy_server/api/routes.py
@@ -4,9 +4,11 @@ from pathlib import Path
 from aiohttp import web
 from aiohttp.web_exceptions import HTTPMethodNotAllowed
 
+from questionpy_common.dev.factories import OptionsFormDefinitionFactory
+
 from questionpy_server.web import ensure_package_and_question_state_exists, json_response
 from questionpy_server.factories import AttemptFactory, AttemptGradedFactory, AttemptStartedFactory,\
-    PackageInfoFactory, FormFactory
+    PackageInfoFactory
 
 from .models import QuestionStateHash, AttemptStartArguments, AttemptGradeArguments, AttemptViewArguments
 
@@ -38,7 +40,7 @@ async def get_package(request: web.Request) -> web.Response:
 @ensure_package_and_question_state_exists
 async def post_options(_request: web.Request, package: Path, question_state: Path,
                        _data: QuestionStateHash) -> web.Response:
-    return json_response(data=FormFactory.build())
+    return json_response(data=OptionsFormDefinitionFactory.build())
 
 
 @routes.post(r'/packages/{package_hash:\w+}/attempt/start')  # type: ignore[arg-type]

--- a/questionpy_server/factories/__init__.py
+++ b/questionpy_server/factories/__init__.py
@@ -1,12 +1,10 @@
 from .package import PackageInfoFactory
-from .options import FormFactory
 from .attempt import AttemptFactory, AttemptGradedFactory, AttemptStartedFactory
 from .question_state import QuestionStateHash
 
 
 __all__ = [
     'PackageInfoFactory',
-    'FormFactory',
     'AttemptFactory', 'AttemptGradedFactory', 'AttemptStartedFactory',
     'QuestionStateHash'
 ]

--- a/questionpy_server/factories/options.py
+++ b/questionpy_server/factories/options.py
@@ -1,7 +1,0 @@
-from pydantic_factories import ModelFactory
-
-from questionpy_server.api.models import Form
-
-
-class FormFactory(ModelFactory):
-    __model__ = Form

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -4,7 +4,9 @@ from typing import Tuple
 from aiohttp import FormData
 from aiohttp.test_utils import TestClient
 
-from questionpy_server.api.models import Form, QuestionStateHash
+from questionpy_common.elements import OptionsFormDefinition
+
+from questionpy_server.api.models import QuestionStateHash
 from questionpy_server.factories.question_state import QuestionStateHashFactory
 from tests.conftest import Packages, Package
 
@@ -42,7 +44,7 @@ async def test_no_package(client: TestClient) -> None:
     assert res.status == 200
 
     res_data = await res.json()
-    Form(**res_data)
+    OptionsFormDefinition(**res_data)
 
 
 async def test_no_question_state(client: TestClient) -> None:
@@ -64,7 +66,7 @@ async def test_no_question_state(client: TestClient) -> None:
     assert res.status == 200
 
     res_data = await res.json()
-    Form(**res_data)
+    OptionsFormDefinition(**res_data)
 
 
 async def test_no_package_and_no_question_state(client: TestClient) -> None:
@@ -92,4 +94,4 @@ async def test_complete(client: TestClient) -> None:
     assert res.status == 200
 
     res_data = await res.json()
-    Form(**res_data)
+    OptionsFormDefinition(**res_data)


### PR DESCRIPTION
Einige Klassen und Funktionen wurden ins [`questionpy-common`](https://github.com/questionpy-org/questionpy-common)-Packet verschoben.  Hiermit greifen wir über das Packet auf diese zu.