### PR TITLE
feature/github-pages: neuer workflow in der CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,6 @@ on:
 jobs:
   ci:
     # https://github.com/questionpy-org/.github
-    uses: questionpy-org/.github/.github/workflows/python-ci.yml@v3
+    uses: questionpy-org/.github/.github/workflows/python-ci.yml@feature/github-pages
     with:
       packages: questionpy_server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,6 @@ on:
 jobs:
   ci:
     # https://github.com/questionpy-org/.github
-    uses: questionpy-org/.github/.github/workflows/python-ci.yml@feature/upload-artifact
+    uses: questionpy-org/.github/.github/workflows/python-ci.yml@v4
     with:
       packages: questionpy_server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,6 @@ on:
 jobs:
   ci:
     # https://github.com/questionpy-org/.github
-    uses: questionpy-org/.github/.github/workflows/python-ci.yml@feature/github-pages
+    uses: questionpy-org/.github/.github/workflows/python-ci.yml@feature/upload-artifact
     with:
       packages: questionpy_server


### PR DESCRIPTION
Neuer PR um den Workflow zum deployen der coverage reports auf github pages auszuprobieren (siehe: [https://github.com/questionpy-org/.github/pull/4](url)).
