### PR TITLE
feat: worker memory limitation

### DIFF
--- a/config.example.ini
+++ b/config.example.ini
@@ -14,11 +14,12 @@
 # Maximum package size in bytes (at least 20MB)
 #max_bytes_package = 20971520
 
+[worker]
 # Maximum amount of running workers
-#max_workers = 10
+#max_workers = 8
 
-# Maximum memory usage of all workers
-#max_bytes_workers = 524288000
+# Maximum combined memory usage of all workers
+#max_memory = 524288000
 
 [cache_package]
 # Maximum cache size in bytes

--- a/config.example.ini
+++ b/config.example.ini
@@ -14,6 +14,12 @@
 # Maximum package size in bytes (at least 20MB)
 #max_bytes_package = 20971520
 
+# Maximum amount of running workers
+#max_workers = 10
+
+# Maximum memory usage of all workers
+#max_bytes_workers = 524288000
+
 [cache_package]
 # Maximum cache size in bytes
 #size = 104857600

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ version = "0.1.1"
 python = "^3.9"
 aiohttp = "^3.8.1"
 pydantic = "^1.9.1"
-questionpy-common = { git = "https://github.com/questionpy-org/questionpy-common.git", rev = "ff24942" }
+questionpy-common = { git = "https://github.com/questionpy-org/questionpy-common.git", rev = "07ca576" }
 watchdog = "^2.2.0"
 
 [tool.poetry.dev-dependencies]

--- a/questionpy_server/app.py
+++ b/questionpy_server/app.py
@@ -17,7 +17,7 @@ class QPyServer:
         self.web_app = web.Application(client_max_size=settings.webservice.max_bytes_main)
         self.web_app.add_routes(routes)
         self.web_app['qpy_server_app'] = self
-        self.worker_pool = WorkerPool(settings.webservice.max_workers, settings.webservice.max_bytes_workers)
+        self.worker_pool = WorkerPool(settings.worker.max_workers, settings.worker.max_memory)
 
         self.package_cache = FileLimitLRU(settings.cache_package.directory, settings.cache_package.size,
                                           extension='.qpy', name='PackageCache')

--- a/questionpy_server/app.py
+++ b/questionpy_server/app.py
@@ -17,7 +17,7 @@ class QPyServer:
         self.web_app = web.Application(client_max_size=settings.webservice.max_bytes_main)
         self.web_app.add_routes(routes)
         self.web_app['qpy_server_app'] = self
-        self.worker_pool = WorkerPool(0, 0)
+        self.worker_pool = WorkerPool(settings.webservice.max_workers, settings.webservice.max_bytes_workers)
 
         self.package_cache = FileLimitLRU(settings.cache_package.directory, settings.cache_package.size,
                                           extension='.qpy', name='PackageCache')

--- a/questionpy_server/settings.py
+++ b/questionpy_server/settings.py
@@ -33,6 +33,8 @@ class WebserviceSettings(BaseModel):
     listen_port: int = 9020
     max_bytes_main: int = Field(5_242_880, const=True)
     max_bytes_package: int = constants.MAX_BYTES_PACKAGE
+    max_workers: int = 10
+    max_bytes_workers: int = 524_288_000
 
     @validator('max_bytes_package')
     # pylint: disable=no-self-argument

--- a/questionpy_server/settings.py
+++ b/questionpy_server/settings.py
@@ -33,8 +33,6 @@ class WebserviceSettings(BaseModel):
     listen_port: int = 9020
     max_bytes_main: int = Field(5_242_880, const=True)
     max_bytes_package: int = constants.MAX_BYTES_PACKAGE
-    max_workers: int = 10
-    max_bytes_workers: int = 524_288_000
 
     @validator('max_bytes_package')
     # pylint: disable=no-self-argument
@@ -42,6 +40,11 @@ class WebserviceSettings(BaseModel):
         if value < constants.MAX_BYTES_PACKAGE:
             raise ValueError(f'max_bytes_package must be bigger than {constants.MAX_BYTES_PACKAGE}')
         return value
+
+
+class WorkerSettings(BaseModel):
+    max_workers: int = 8
+    max_memory: int = 524_288_000
 
 
 class PackageCacheSettings(BaseModel):
@@ -77,6 +80,7 @@ class CollectorSettings(BaseModel):
 
 class Settings(BaseSettings):
     webservice: WebserviceSettings
+    worker: WorkerSettings
     cache_package: PackageCacheSettings
     cache_question_state: QuestionStateCacheSettings
     collector: CollectorSettings

--- a/questionpy_server/worker/controller.py
+++ b/questionpy_server/worker/controller.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Optional
 from questionpy_common.manifest import Manifest
 from questionpy_common.elements import OptionsFormDefinition
-from questionpy_common.misc import Bytes, ByteSize
+from questionpy_common.misc import Size, SizeUnit
 from .worker import WorkerProcessBase, WorkerProcess, WorkerResourceLimits
 from .runtime.messages import GetQPyPackageManifest, GetOptionsFormDefinition
 
@@ -71,7 +71,7 @@ class WorkerPool:
             if context is None:
                 context = 0
             try:
-                limits = WorkerResourceLimits(max_memory=Bytes(200, ByteSize.MiB),
+                limits = WorkerResourceLimits(max_memory=Size(200, SizeUnit.MiB),
                                               max_cpu_time_seconds_per_call=10)  # TODO
 
                 # Wait until there is enough memory available.

--- a/questionpy_server/worker/controller.py
+++ b/questionpy_server/worker/controller.py
@@ -1,9 +1,11 @@
+from asyncio import Semaphore, to_thread, Lock
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Optional
 from questionpy_common.manifest import Manifest
 from questionpy_common.elements import OptionsFormDefinition
+from questionpy_common.misc import Bytes, ByteSize
 from .worker import WorkerProcessBase, WorkerProcess, WorkerResourceLimits
 from .runtime.messages import GetQPyPackageManifest, GetOptionsFormDefinition
 
@@ -33,7 +35,24 @@ class WorkerPool:
         :param max_workers: maximum number of workers being executed in parallel
         :param max_memory: maximum memory (in bytes) that all workers in the pool are allowed to consume
         """
-        #  TODO handle arguments
+        self.max_workers = max_workers
+        self.max_memory = max_memory
+        self._processes: list[WorkerProcess] = []
+
+        self._semaphore: Optional[Semaphore] = None
+        self._lock: Optional[Lock] = None
+
+    def get_current_memory_usage(self) -> Bytes:
+        total = 0
+        for process in self._processes:
+            total += process.get_resource_usage().memory_bytes
+        return Bytes(total)
+
+    async def _wait_for_memory(self) -> None:
+        while True:
+            memory = await to_thread(self.get_current_memory_usage)
+            if memory < self.max_memory:
+                break
 
     @asynccontextmanager
     async def get_worker(self, package: Path, lms: int, context: Optional[int]) -> AsyncIterator[Worker]:
@@ -46,16 +65,35 @@ class WorkerPool:
         :param context: context id within the lms
         :return: a worker
         """
-        process = None
-        if context is None:
-            context = 0
-        try:
-            example_limits = WorkerResourceLimits(max_memory_bytes=1024, max_cpu_time_seconds_per_call=10)  # TODO
-            process = WorkerProcess(package, lms, context, example_limits)
-            await process.start()
+        if not self._semaphore:
+            self._semaphore = Semaphore(self.max_workers)
 
-            worker = Worker(process)
-            yield worker
-        finally:
-            if process:
-                await process.stop(10)
+        if not self._lock:
+            self._lock = Lock()
+
+        # Limit the amount of running workers.
+        async with self._semaphore:
+
+            process = None
+            if context is None:
+                context = 0
+            try:
+                example_limits = WorkerResourceLimits(max_memory_bytes=Bytes(300, ByteSize.MiB),
+                                                      max_cpu_time_seconds_per_call=10)  # TODO
+                process = WorkerProcess(package, lms, context, example_limits)
+
+                # Ensure FIFO.
+                async with self._lock:
+                    # Wait for RAM to be available.
+                    await self._wait_for_memory()
+
+                self._processes.append(process)
+                await process.start()
+
+                worker = Worker(process)
+
+                yield worker
+            finally:
+                if process:
+                    await process.stop(10)
+                    self._processes.remove(process)

--- a/questionpy_server/worker/exception.py
+++ b/questionpy_server/worker/exception.py
@@ -1,0 +1,18 @@
+class WorkerNotRunningError(Exception):
+    pass
+
+
+class WorkerStartError(Exception):
+    pass
+
+
+class WorkerMemoryLimitExceededError(Exception):
+    pass
+
+
+class WorkerCPUTimeLimitExceededError(Exception):
+    pass
+
+
+class WorkerUnknownError(Exception):
+    pass

--- a/questionpy_server/worker/runtime/lib.py
+++ b/questionpy_server/worker/runtime/lib.py
@@ -6,7 +6,7 @@ from io import BufferedReader, RawIOBase
 from pathlib import Path
 from typing import Any, Optional, Union, Callable, TypeVar, TYPE_CHECKING
 
-from questionpy_common.misc import Bytes
+from questionpy_common.misc import Size
 
 from .messages import InitWorker, Exit, get_message_bytes, messages_header_struct, Message, MessageIds, \
     MessageToWorker, MessageToServer, InvalidMessageIdError, GetQPyPackageManifest, LoadQPyPackage, \
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 @dataclass
 class WorkerResourceLimits:
     """Maximum resources that a worker process is allowed to consume."""
-    max_memory: Bytes
+    max_memory: Size
     max_cpu_time_seconds_per_call: float
 
 
@@ -95,7 +95,7 @@ class WorkerManager:
         if not isinstance(init_msg, InitWorker):
             raise BootstrapError()
 
-        self.limits = WorkerResourceLimits(max_memory=Bytes(init_msg.max_memory),
+        self.limits = WorkerResourceLimits(max_memory=Size(init_msg.max_memory),
                                            max_cpu_time_seconds_per_call=init_msg.max_cpu_time)
         # Limit memory usage.
         resource.setrlimit(resource.RLIMIT_AS, (self.limits.max_memory, self.limits.max_memory))

--- a/questionpy_server/worker/runtime/lib.py
+++ b/questionpy_server/worker/runtime/lib.py
@@ -5,6 +5,9 @@ from dataclasses import dataclass
 from io import BufferedReader, RawIOBase
 from pathlib import Path
 from typing import Any, Optional, Union, Callable, TypeVar, TYPE_CHECKING
+
+from questionpy_common.misc import Bytes
+
 from .messages import InitWorker, Exit, get_message_bytes, messages_header_struct, Message, MessageIds, \
     MessageToWorker, MessageToServer, InvalidMessageIdError, GetQPyPackageManifest, LoadQPyPackage, \
     GetOptionsFormDefinition, WorkerError
@@ -17,7 +20,7 @@ if TYPE_CHECKING:
 @dataclass
 class WorkerResourceLimits:
     """Maximum resources that a worker process is allowed to consume."""
-    max_memory_bytes: int
+    max_memory: Bytes
     max_cpu_time_seconds_per_call: float
 
 
@@ -92,10 +95,10 @@ class WorkerManager:
         if not isinstance(init_msg, InitWorker):
             raise BootstrapError()
 
-        self.limits = WorkerResourceLimits(max_memory_bytes=init_msg.max_memory,
+        self.limits = WorkerResourceLimits(max_memory=Bytes(init_msg.max_memory),
                                            max_cpu_time_seconds_per_call=init_msg.max_cpu_time)
         # Limit memory usage.
-        resource.setrlimit(resource.RLIMIT_AS, (self.limits.max_memory_bytes, self.limits.max_memory_bytes))
+        resource.setrlimit(resource.RLIMIT_AS, (self.limits.max_memory, self.limits.max_memory))
 
         self.server_connection.send_message(InitWorker.Response())
 

--- a/questionpy_server/worker/worker.py
+++ b/questionpy_server/worker/worker.py
@@ -195,7 +195,7 @@ class WorkerProcess(WorkerProcessBase):
             msg_after = ""
             if self.stderr_skipped_data:
                 msg_after += f" (additional {Size(self.stderr_skipped_data)} were skipped)."
-            log.warning("%s%s%s ", msg, self.stderr_data.decode('utf-8'), msg_after)
+            log.warning("%s%s%s ", msg, self.stderr_data.decode('utf-8', errors='replace'), msg_after)
         self.stderr_data = bytearray()
         self.stderr_skipped_data = 0
 

--- a/tests/collector/test_indexer.py
+++ b/tests/collector/test_indexer.py
@@ -19,7 +19,7 @@ from tests.conftest import PACKAGE
 @pytest.mark.parametrize('kind', [PACKAGE.path, PACKAGE.manifest])
 @patch('questionpy_server.collector.lms_collector.LMSCollector', spec=LMSCollector)
 async def test_register_package_with_path_and_manifest(collector: LMSCollector, kind: Union[Path, Manifest]) -> None:
-    indexer = Indexer(WorkerPool(0, 0))
+    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
     await indexer.register_package(PACKAGE.hash, kind, collector)
 
     # Package is accessible by hash.
@@ -31,7 +31,7 @@ async def test_register_package_with_path_and_manifest(collector: LMSCollector, 
 
 @patch('questionpy_server.collector.lms_collector.LMSCollector', spec=LMSCollector)
 async def test_register_package_from_lms(collector: LMSCollector) -> None:
-    indexer = Indexer(WorkerPool(0, 0))
+    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
     await indexer.register_package(PACKAGE.hash, PACKAGE.manifest, collector)
 
     # Package is not accessible by name and version.
@@ -52,7 +52,7 @@ async def test_register_package_from_local_and_repo_collector(collector: BaseCol
     # Create mock.
     collector = patch(collector.__module__, spec=collector).start()
 
-    indexer = Indexer(WorkerPool(0, 0))
+    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
     await indexer.register_package(PACKAGE.hash, PACKAGE.manifest, collector)
 
     # Package is accessible by hash.
@@ -78,7 +78,7 @@ async def test_register_package_from_local_and_repo_collector(collector: BaseCol
 
 
 async def test_register_package_with_same_hash_as_existing_package() -> None:
-    indexer = Indexer(WorkerPool(0, 0))
+    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
 
     # Register package from local collector.
     local_collector = patch(LocalCollector.__module__, spec=LocalCollector).start()
@@ -113,7 +113,7 @@ async def test_register_two_packages_with_same_manifest_but_different_hashes(cap
     collector = patch(LocalCollector.__module__, spec=LocalCollector).start()
 
     # Register a package.
-    indexer = Indexer(WorkerPool(0, 0))
+    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
     await indexer.register_package(PACKAGE.hash, PACKAGE.manifest, collector)
 
     with caplog.at_level(logging.WARNING):
@@ -126,7 +126,7 @@ async def test_register_two_packages_with_same_manifest_but_different_hashes(cap
 
 
 async def test_unregister_package_with_lms_source() -> None:
-    indexer = Indexer(WorkerPool(0, 0))
+    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
     collector = patch(LMSCollector.__module__, spec=LMSCollector).start()
     await indexer.register_package(PACKAGE.hash, PACKAGE.manifest, collector)
 
@@ -139,7 +139,7 @@ async def test_unregister_package_with_lms_source() -> None:
 
 @pytest.mark.parametrize('collector', [LocalCollector, RepoCollector])
 async def test_unregister_package_with_local_and_repo_source(collector: BaseCollector) -> None:
-    indexer = Indexer(WorkerPool(0, 0))
+    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
     collector = patch(collector.__module__, spec=collector).start()
     await indexer.register_package(PACKAGE.hash, PACKAGE.manifest, collector)
 
@@ -159,7 +159,7 @@ async def test_unregister_package_with_local_and_repo_source(collector: BaseColl
 
 
 async def test_unregister_package_with_multiple_sources() -> None:
-    indexer = Indexer(WorkerPool(0, 0))
+    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
 
     # Register package from local, repo, and LMS collector.
     lms_collector = patch(LMSCollector.__module__, spec=LMSCollector).start()

--- a/tests/collector/test_lms_collector.py
+++ b/tests/collector/test_lms_collector.py
@@ -22,7 +22,7 @@ def create_lms_collector(tmp_path_factory: TempPathFactory) -> tuple[LMSCollecto
 
     path = tmp_path_factory.mktemp('qpy')
     cache = FileLimitLRU(path, 20 * 1024 * 1024, extension='.qpy')
-    indexer = Indexer(WorkerPool(0, 0))
+    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
     return LMSCollector(cache, indexer), cache
 
 

--- a/tests/collector/test_local_collector.py
+++ b/tests/collector/test_local_collector.py
@@ -22,7 +22,7 @@ def create_local_collector(tmp_path_factory: TempPathFactory) -> tuple[LocalColl
     """
 
     path = tmp_path_factory.mktemp('qpy')
-    indexer = Indexer(WorkerPool(0, 0))
+    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
     return LocalCollector(path, indexer), path
 
 
@@ -32,7 +32,7 @@ async def test_ignore_files_with_wrong_extension(tmp_path_factory: TempPathFacto
     ignore_file = directory / 'wrong.extension'
     ignore_file.touch()
 
-    indexer = Indexer(WorkerPool(0, 0))
+    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
     local_collector = LocalCollector(directory, indexer)
 
     async with local_collector:
@@ -48,7 +48,7 @@ async def test_ignore_files_with_wrong_extension(tmp_path_factory: TempPathFacto
 
 async def test_package_exists_before_init(tmp_path_factory: TempPathFactory) -> None:
     path = tmp_path_factory.mktemp('qpy')
-    indexer = Indexer(WorkerPool(0, 0))
+    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
     local_collector = LocalCollector(path, indexer)
 
     package_path = copy(PACKAGE.path, path)
@@ -199,7 +199,7 @@ async def test_package_gets_moved_to_different_folder(tmp_path_factory: TempPath
         # Use new_directory as the directory to be watched and directory to be the new directory of the package.
         directory, new_directory = new_directory, directory
 
-    indexer = Indexer(WorkerPool(0, 0))
+    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
     local_collector = LocalCollector(directory, indexer)
 
     # Create a package in the directory.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,7 @@ def qpy_server(tmp_path_factory: TempPathFactory) -> QPyServer:
     server = QPyServer(Settings(
         config_files=(),
         webservice=WebserviceSettings(listen_address="127.0.0.1", listen_port=0),
-        worker=WorkerSettings(max_workers=4, max_memory=104_857_600),
+        worker=WorkerSettings(max_workers=8, max_memory=524_288_000),
         cache_package=PackageCacheSettings(directory=package_cache_directory),
         cache_question_state=QuestionStateCacheSettings(directory=question_state_cache_directory),
         collector=CollectorSettings()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ from questionpy_common.manifest import Manifest
 
 from questionpy_server.app import QPyServer
 from questionpy_server.settings import Settings, WebserviceSettings, PackageCacheSettings, CollectorSettings, \
-    QuestionStateCacheSettings
+    QuestionStateCacheSettings, WorkerSettings
 
 
 def get_file_hash(path: Path) -> str:
@@ -54,6 +54,7 @@ def qpy_server(tmp_path_factory: TempPathFactory) -> QPyServer:
     server = QPyServer(Settings(
         config_files=(),
         webservice=WebserviceSettings(listen_address="127.0.0.1", listen_port=0),
+        worker=WorkerSettings(max_workers=4, max_memory=104_857_600),
         cache_package=PackageCacheSettings(directory=package_cache_directory),
         cache_question_state=QuestionStateCacheSettings(directory=question_state_cache_directory),
         collector=CollectorSettings()


### PR DESCRIPTION
Den `WorkerPool` kann man nun in der Anzahl der erstellbaren `Worker` und dem zur Verfügung stehenden RAM einschränken.

Sollten bereits die maximale Anzahl an `Worker` laufen und/oder zu viel RAM vom `WorkerPool` benutzt werden, wartet der aufrufende Task bis wieder genügend Ressourcen vorhanden sind.

Ein einzelner `Worker` kann aktuell bis zu 300 MiB RAM beanspruchen.
