### PR TITLE
Hotfix/test inconsistency

### DIFF
--- a/tests/collector/test_indexer.py
+++ b/tests/collector/test_indexer.py
@@ -13,33 +13,33 @@ from questionpy_server.collector.lms_collector import LMSCollector
 from questionpy_server.collector.local_collector import LocalCollector
 from questionpy_server.collector.repo_collector import RepoCollector
 from questionpy_server.package import PackageSources
-from tests.conftest import PACKAGES
+from tests.conftest import PACKAGE
 
 
-@pytest.mark.parametrize('kind', [PACKAGES[0].path, PACKAGES[0].manifest])
+@pytest.mark.parametrize('kind', [PACKAGE.path, PACKAGE.manifest])
 @patch('questionpy_server.collector.lms_collector.LMSCollector', spec=LMSCollector)
 async def test_register_package_with_path_and_manifest(collector: LMSCollector, kind: Union[Path, Manifest]) -> None:
     indexer = Indexer(WorkerPool(0, 0))
-    await indexer.register_package(PACKAGES[0].hash, kind, collector)
+    await indexer.register_package(PACKAGE.hash, kind, collector)
 
     # Package is accessible by hash.
-    package = indexer.get_by_hash(PACKAGES[0].hash)
+    package = indexer.get_by_hash(PACKAGE.hash)
     assert package is not None
-    assert package.hash == PACKAGES[0].hash
-    assert package.manifest == PACKAGES[0].manifest
+    assert package.hash == PACKAGE.hash
+    assert package.manifest == PACKAGE.manifest
 
 
 @patch('questionpy_server.collector.lms_collector.LMSCollector', spec=LMSCollector)
 async def test_register_package_from_lms(collector: LMSCollector) -> None:
     indexer = Indexer(WorkerPool(0, 0))
-    await indexer.register_package(PACKAGES[0].hash, PACKAGES[0].manifest, collector)
+    await indexer.register_package(PACKAGE.hash, PACKAGE.manifest, collector)
 
     # Package is not accessible by name and version.
-    package = indexer.get_by_name_and_version(PACKAGES[0].manifest.short_name, PACKAGES[0].manifest.version)
+    package = indexer.get_by_name_and_version(PACKAGE.manifest.short_name, PACKAGE.manifest.version)
     assert package is None
 
     # Package is not accessible by name.
-    packages_by_name = indexer.get_by_name(PACKAGES[0].manifest.short_name)
+    packages_by_name = indexer.get_by_name(PACKAGE.manifest.short_name)
     assert len(packages_by_name) == 0
 
     # Package is not accessible by retrieving all packages.
@@ -53,21 +53,21 @@ async def test_register_package_from_local_and_repo_collector(collector: BaseCol
     collector = patch(collector.__module__, spec=collector).start()
 
     indexer = Indexer(WorkerPool(0, 0))
-    await indexer.register_package(PACKAGES[0].hash, PACKAGES[0].manifest, collector)
+    await indexer.register_package(PACKAGE.hash, PACKAGE.manifest, collector)
 
     # Package is accessible by hash.
-    package = indexer.get_by_hash(PACKAGES[0].hash)
+    package = indexer.get_by_hash(PACKAGE.hash)
     assert package is not None
-    assert package.hash == PACKAGES[0].hash
-    assert package.manifest == PACKAGES[0].manifest
+    assert package.hash == PACKAGE.hash
+    assert package.manifest == PACKAGE.manifest
 
     # Package is accessible by name and version.
-    new_package = indexer.get_by_name_and_version(PACKAGES[0].manifest.short_name, PACKAGES[0].manifest.version)
+    new_package = indexer.get_by_name_and_version(PACKAGE.manifest.short_name, PACKAGE.manifest.version)
     assert new_package is not None
     assert new_package is package
 
     # Package is accessible by name.
-    packages_by_name = indexer.get_by_name(PACKAGES[0].manifest.short_name)
+    packages_by_name = indexer.get_by_name(PACKAGE.manifest.short_name)
     assert len(packages_by_name) == 1
     assert packages_by_name[package.manifest.version] is package
 
@@ -82,24 +82,24 @@ async def test_register_package_with_same_hash_as_existing_package() -> None:
 
     # Register package from local collector.
     local_collector = patch(LocalCollector.__module__, spec=LocalCollector).start()
-    package = await indexer.register_package(PACKAGES[0].hash, PACKAGES[0].manifest, local_collector)
+    package = await indexer.register_package(PACKAGE.hash, PACKAGE.manifest, local_collector)
 
     # Register package from repo collector.
     repo_collector = patch(RepoCollector.__module__, spec=RepoCollector).start()
-    package_2 = await indexer.register_package(PACKAGES[0].hash, PACKAGES[0].manifest, repo_collector)
+    package_2 = await indexer.register_package(PACKAGE.hash, PACKAGE.manifest, repo_collector)
     assert package is package_2
 
     # Register package from LMS collector.
     with patch.object(PackageSources, 'add') as add:
         lms_collector = patch(LMSCollector.__module__, spec=LMSCollector).start()
-        package_3 = await indexer.register_package(PACKAGES[0].hash, PACKAGES[0].path, lms_collector)
+        package_3 = await indexer.register_package(PACKAGE.hash, PACKAGE.path, lms_collector)
         assert package is package_3
 
         # Source gets added to package.
         add.assert_called_once_with(lms_collector)
 
     # Package will only be listed once.
-    packages_by_name = indexer.get_by_name(PACKAGES[0].manifest.short_name)
+    packages_by_name = indexer.get_by_name(PACKAGE.manifest.short_name)
     assert len(packages_by_name) == 1
     assert packages_by_name[package.manifest.version] is package
 
@@ -114,26 +114,26 @@ async def test_register_two_packages_with_same_manifest_but_different_hashes(cap
 
     # Register a package.
     indexer = Indexer(WorkerPool(0, 0))
-    await indexer.register_package(PACKAGES[0].hash, PACKAGES[0].manifest, collector)
+    await indexer.register_package(PACKAGE.hash, PACKAGE.manifest, collector)
 
     with caplog.at_level(logging.WARNING):
         # Register same package with different hash and same manifest.
-        await indexer.register_package("different_hash", PACKAGES[0].manifest, collector)
+        await indexer.register_package("different_hash", PACKAGE.manifest, collector)
 
-    message = f'The package {PACKAGES[0].manifest.short_name} ({PACKAGES[0].manifest.version}) with hash: ' \
-              f'different_hash already exists with a different hash: {PACKAGES[0].hash}.'
+    message = f'The package {PACKAGE.manifest.short_name} ({PACKAGE.manifest.version}) with hash: ' \
+              f'different_hash already exists with a different hash: {PACKAGE.hash}.'
     assert caplog.record_tuples == [('questionpy-server:indexer', logging.WARNING, message)]
 
 
 async def test_unregister_package_with_lms_source() -> None:
     indexer = Indexer(WorkerPool(0, 0))
     collector = patch(LMSCollector.__module__, spec=LMSCollector).start()
-    await indexer.register_package(PACKAGES[0].hash, PACKAGES[0].manifest, collector)
+    await indexer.register_package(PACKAGE.hash, PACKAGE.manifest, collector)
 
-    await indexer.unregister_package(PACKAGES[0].hash, collector)
+    await indexer.unregister_package(PACKAGE.hash, collector)
 
     # Package is not accessible after unregistering.
-    package = indexer.get_by_hash(PACKAGES[0].hash)
+    package = indexer.get_by_hash(PACKAGE.hash)
     assert package is None
 
 
@@ -141,20 +141,20 @@ async def test_unregister_package_with_lms_source() -> None:
 async def test_unregister_package_with_local_and_repo_source(collector: BaseCollector) -> None:
     indexer = Indexer(WorkerPool(0, 0))
     collector = patch(collector.__module__, spec=collector).start()
-    await indexer.register_package(PACKAGES[0].hash, PACKAGES[0].manifest, collector)
+    await indexer.register_package(PACKAGE.hash, PACKAGE.manifest, collector)
 
-    await indexer.unregister_package(PACKAGES[0].hash, collector)
+    await indexer.unregister_package(PACKAGE.hash, collector)
 
     # Package is not accessible after unregistering.
-    package = indexer.get_by_hash(PACKAGES[0].hash)
+    package = indexer.get_by_hash(PACKAGE.hash)
     assert package is None
 
     # Package is not accessible by name and version.
-    package = indexer.get_by_name_and_version(PACKAGES[0].manifest.short_name, PACKAGES[0].manifest.version)
+    package = indexer.get_by_name_and_version(PACKAGE.manifest.short_name, PACKAGE.manifest.version)
     assert package is None
 
     # Package is not accessible by name.
-    packages = indexer.get_by_name(PACKAGES[0].manifest.short_name)
+    packages = indexer.get_by_name(PACKAGE.manifest.short_name)
     assert len(packages) == 0
 
 
@@ -163,47 +163,47 @@ async def test_unregister_package_with_multiple_sources() -> None:
 
     # Register package from local, repo, and LMS collector.
     lms_collector = patch(LMSCollector.__module__, spec=LMSCollector).start()
-    await indexer.register_package(PACKAGES[0].hash, PACKAGES[0].manifest, lms_collector)
+    await indexer.register_package(PACKAGE.hash, PACKAGE.manifest, lms_collector)
 
     local_collector = patch(LocalCollector.__module__, spec=LocalCollector).start()
-    await indexer.register_package(PACKAGES[0].hash, PACKAGES[0].manifest, local_collector)
+    await indexer.register_package(PACKAGE.hash, PACKAGE.manifest, local_collector)
 
     repo_collector = patch(RepoCollector.__module__, spec=RepoCollector).start()
-    await indexer.register_package(PACKAGES[0].hash, PACKAGES[0].manifest, repo_collector)
+    await indexer.register_package(PACKAGE.hash, PACKAGE.manifest, repo_collector)
 
     # Unregister package from local collector.
-    await indexer.unregister_package(PACKAGES[0].hash, local_collector)
+    await indexer.unregister_package(PACKAGE.hash, local_collector)
 
     # Package is still accessible by hash.
-    package = indexer.get_by_hash(PACKAGES[0].hash)
+    package = indexer.get_by_hash(PACKAGE.hash)
     assert package is not None
 
     # Package is still accessible by name and version.
-    package = indexer.get_by_name_and_version(PACKAGES[0].manifest.short_name, PACKAGES[0].manifest.version)
+    package = indexer.get_by_name_and_version(PACKAGE.manifest.short_name, PACKAGE.manifest.version)
     assert package is not None
 
     # Package is still accessible by name.
-    packages = indexer.get_by_name(PACKAGES[0].manifest.short_name)
+    packages = indexer.get_by_name(PACKAGE.manifest.short_name)
     assert len(packages) == 1
 
     # Unregister package from repo collector.
-    await indexer.unregister_package(PACKAGES[0].hash, repo_collector)
+    await indexer.unregister_package(PACKAGE.hash, repo_collector)
 
     # Package is still accessible by hash.
-    package = indexer.get_by_hash(PACKAGES[0].hash)
+    package = indexer.get_by_hash(PACKAGE.hash)
     assert package is not None
 
     # Package is not accessible by name and version.
-    package = indexer.get_by_name_and_version(PACKAGES[0].manifest.short_name, PACKAGES[0].manifest.version)
+    package = indexer.get_by_name_and_version(PACKAGE.manifest.short_name, PACKAGE.manifest.version)
     assert package is None
 
     # Package is not accessible by name.
-    packages = indexer.get_by_name(PACKAGES[0].manifest.short_name)
+    packages = indexer.get_by_name(PACKAGE.manifest.short_name)
     assert len(packages) == 0
 
     # Unregister package from LMS collector.
-    await indexer.unregister_package(PACKAGES[0].hash, lms_collector)
+    await indexer.unregister_package(PACKAGE.hash, lms_collector)
 
     # Package is not accessible by hash.
-    package = indexer.get_by_hash(PACKAGES[0].hash)
+    package = indexer.get_by_hash(PACKAGE.hash)
     assert package is None

--- a/tests/collector/test_lms_collector.py
+++ b/tests/collector/test_lms_collector.py
@@ -9,7 +9,7 @@ from questionpy_server.collector.indexer import Indexer
 from questionpy_server.collector.lms_collector import LMSCollector
 from questionpy_server.package import Package
 from questionpy_server.web import HashContainer
-from tests.conftest import PACKAGES
+from tests.conftest import PACKAGE
 
 
 def create_lms_collector(tmp_path_factory: TempPathFactory) -> tuple[LMSCollector, FileLimitLRU]:
@@ -30,7 +30,7 @@ async def test_package_in_cache_before_init(tmp_path_factory: TempPathFactory) -
     cache = FileLimitLRU(tmp_path_factory.mktemp('qpy'), 20 * 1024 * 1024, extension='.qpy')
 
     # Put package into cache.
-    await cache.put(PACKAGES[0].hash, PACKAGES[0].path.read_bytes())
+    await cache.put(PACKAGE.hash, PACKAGE.path.read_bytes())
 
     # Create and start collector.
     with patch(Indexer.__module__, spec=Indexer) as indexer:
@@ -41,7 +41,7 @@ async def test_package_in_cache_before_init(tmp_path_factory: TempPathFactory) -
         indexer.register_package.assert_called_once()
 
     # Check if package is registered.
-    package = Package(PACKAGES[0].hash, PACKAGES[0].manifest)
+    package = Package(PACKAGE.hash, PACKAGE.manifest)
     path = await lms_collector.get_path(package)
 
     assert path is not None
@@ -50,14 +50,14 @@ async def test_package_in_cache_before_init(tmp_path_factory: TempPathFactory) -
 async def test_put(tmp_path_factory: TempPathFactory) -> None:
     lms_collector, cache = create_lms_collector(tmp_path_factory)
 
-    package_bytes = PACKAGES[0].path.read_bytes()
-    hash_container = HashContainer(package_bytes, PACKAGES[0].hash)
+    package_bytes = PACKAGE.path.read_bytes()
+    hash_container = HashContainer(package_bytes, PACKAGE.hash)
 
     # Put package into collector.
     package = await lms_collector.put(hash_container)
 
     # Check if package is stored in cache.
-    cache_path = cache.get(PACKAGES[0].hash)
+    cache_path = cache.get(PACKAGE.hash)
     lms_path = await lms_collector.get_path(package)
     assert cache_path == lms_path
 
@@ -69,14 +69,14 @@ async def test_put(tmp_path_factory: TempPathFactory) -> None:
 async def test_get_non_existing_file(tmp_path_factory: TempPathFactory) -> None:
     lms_collector, cache = create_lms_collector(tmp_path_factory)
 
-    package_bytes = PACKAGES[0].path.read_bytes()
-    hash_container = HashContainer(package_bytes, PACKAGES[0].hash)
+    package_bytes = PACKAGE.path.read_bytes()
+    hash_container = HashContainer(package_bytes, PACKAGE.hash)
 
     # Put package into collector.
     package = await lms_collector.put(hash_container)
 
     # Remove package from cache.
-    await cache.remove(PACKAGES[0].hash)
+    await cache.remove(PACKAGE.hash)
 
     with pytest.raises(FileNotFoundError):
         await lms_collector.get_path(package)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,9 @@ class TestPackage:
             self.manifest = Manifest(**json.loads(manifest_path.read_bytes()))
 
 
-PACKAGES: list[TestPackage] = [TestPackage(path) for path in Path('tests/test_data/package').iterdir()]
+package_dir = Path('tests/test_data/package/')
+PACKAGE = TestPackage(package_dir / 'package_1.qpy')
+PACKAGE_2 = TestPackage(package_dir / 'package_2.qpy')
 
 
 @pytest.fixture

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -6,15 +6,15 @@ from aiohttp.test_utils import TestClient
 from pydantic import parse_obj_as
 
 from questionpy_server.api.models import PackageInfo
-from tests.conftest import PACKAGES
+from tests.conftest import PACKAGE
 
 
 async def test_post_package(client: TestClient) -> None:
-    with PACKAGES[0].path.open('rb') as file:
+    with PACKAGE.path.open('rb') as file:
         payload = FormData()
         payload.add_field('package', file)
 
-        res = await client.request('POST', f'/packages/{PACKAGES[0].hash}', data=payload)
+        res = await client.request('POST', f'/packages/{PACKAGE.hash}', data=payload)
 
     assert res.status == 200
     data = await res.json()
@@ -23,11 +23,11 @@ async def test_post_package(client: TestClient) -> None:
 
 async def test_post_package_faulty(client: TestClient) -> None:
     # Package hash is not matching the package.
-    with PACKAGES[0].path.open('rb') as file:
+    with PACKAGE.path.open('rb') as file:
         payload = FormData()
         payload.add_field('package', file)
 
-        res = await client.request('POST', f'/packages/{PACKAGES[0].hash + "x"}', data=payload)
+        res = await client.request('POST', f'/packages/{PACKAGE.hash + "x"}', data=payload)
 
     assert res.status == 400
     text = await res.text()
@@ -37,7 +37,7 @@ async def test_post_package_faulty(client: TestClient) -> None:
     payload = FormData()
     payload.add_field('ignore', BytesIO())  # To force multipart/form-data.
 
-    res = await client.request('POST', f'/packages/{PACKAGES[0].hash}', data=payload)
+    res = await client.request('POST', f'/packages/{PACKAGE.hash}', data=payload)
     assert res.status == 400
     text = await res.text()
     assert text == 'No package found in multipart/form-data'
@@ -49,27 +49,3 @@ async def test_packages(client: TestClient) -> None:
     assert res.status == 200
     data = await res.json()
     parse_obj_as(List[PackageInfo], data)
-
-
-async def test_extract_info(client: TestClient) -> None:
-    with PACKAGES[0].path.open('rb') as file:
-        payload = FormData()
-        payload.add_field('package', file)
-
-        res = await client.request('POST', '/package-extract-info', data=payload)
-
-    assert res.status == 201
-    data = await res.json()
-    parse_obj_as(PackageInfo, data)
-
-
-async def test_extract_info_faulty(client: TestClient) -> None:
-    # Request without package in payload.
-    payload = FormData()
-    payload.add_field('ignore', BytesIO())
-
-    res = await client.request('POST', '/package-extract-info', data=payload)
-
-    assert res.status == 400
-    text = await res.text()
-    assert text == 'No package found in multipart/form-data'

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -49,3 +49,27 @@ async def test_packages(client: TestClient) -> None:
     assert res.status == 200
     data = await res.json()
     parse_obj_as(List[PackageInfo], data)
+
+
+async def test_extract_info(client: TestClient) -> None:
+    with PACKAGE.path.open('rb') as file:
+        payload = FormData()
+        payload.add_field('package', file)
+
+        res = await client.request('POST', '/package-extract-info', data=payload)
+
+    assert res.status == 201
+    data = await res.json()
+    parse_obj_as(PackageInfo, data)
+
+
+async def test_extract_info_faulty(client: TestClient) -> None:
+    # Request without package in payload.
+    payload = FormData()
+    payload.add_field('ignore', BytesIO())
+
+    res = await client.request('POST', '/package-extract-info', data=payload)
+
+    assert res.status == 400
+    text = await res.text()
+    assert text == 'No package found in multipart/form-data'


### PR DESCRIPTION
Beim Modifizieren eines Pakets wird das `FileModifiedEvent` mehrmals hintereinander getriggert. Da sich der Hash (und der Inhalt) des Pakets aber nur einmal ändert, wird nun auch darauf geachtet, ob dies auch der Fall ist. Wenn nicht, wird das Event ignoriert.
Das war zuvor nicht der Fall, was dazu führte, dass ein Test fehlgeschlagen ist.