### PR TITLE
chore: disable certain pylint warnings in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+# pylint: disable=redefined-outer-name
+
 import json
 from dataclasses import dataclass
 from hashlib import sha256

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,3 +1,5 @@
+# pylint: disable=redefined-outer-name, protected-access
+
 from dataclasses import dataclass
 from pathlib import Path
 from string import ascii_lowercase


### PR DESCRIPTION
Durch die Löschung des `pylint-pytest` Plugins in #25, müssen nun bestimmte `pylint` Warnungen (z.B. `redefined-outer-name` und `protected-access`) im Test-Code ignoriert werden.