### PR TITLE
refactor: use `Size` instead of `int` when handling with bytes

### DIFF
--- a/config.example.ini
+++ b/config.example.ini
@@ -11,26 +11,26 @@
 # The port the http server should bind to
 #listen_port = 9020
 
-# Maximum package size in bytes (at least 20MB)
-#max_bytes_package = 20971520
+# Maximum package size (at least 20 MiB)
+#max_package_size = 20 MiB
 
 [worker]
 # Maximum amount of running workers
 #max_workers = 8
 
 # Maximum combined memory usage of all workers
-#max_memory = 524288000
+#max_memory = 500 MiB
 
 [cache_package]
-# Maximum cache size in bytes
-#size = 104857600
+# Maximum cache size
+#size = 100 MiB
 
 # The path of the cache (relative or absolute)
 #path = cache/packages
 
 [cache_question_state]
-# Maximum cache size in bytes
-#size = 20971520
+# Maximum cache size
+#size = 20 MiB
 
 # The path of the cache (relative or absolute)
 #path = cache/question_states

--- a/questionpy_server/app.py
+++ b/questionpy_server/app.py
@@ -14,7 +14,7 @@ from .worker.controller import WorkerPool
 class QPyServer:
     def __init__(self, settings: Settings):
         self.settings: Settings = settings
-        self.web_app = web.Application(client_max_size=settings.webservice.max_bytes_main)
+        self.web_app = web.Application(client_max_size=settings.webservice.max_main_size)
         self.web_app.add_routes(routes)
         self.web_app['qpy_server_app'] = self
         self.worker_pool = WorkerPool(settings.worker.max_workers, settings.worker.max_memory)

--- a/questionpy_server/collector/indexer.py
+++ b/questionpy_server/collector/indexer.py
@@ -26,7 +26,6 @@ class Indexer:
         self._index_by_hash: dict[str, Package] = {}
         self._index_by_name: dict[str, dict[str, Package]] = {}
 
-        # TODO: initialize Lock here if the minimum supported Python version is 3.10 or above
         self._lock: Optional[Lock] = None
 
     def get_by_hash(self, package_hash: str) -> Optional[Package]:

--- a/questionpy_server/misc.py
+++ b/questionpy_server/misc.py
@@ -3,6 +3,8 @@ from inspect import Parameter, signature, isclass
 from pathlib import Path
 from typing import Callable, List, Type, Tuple
 
+from questionpy_common.misc import Size, SizeUnit
+
 from questionpy_server.types import RouteHandler, M
 
 
@@ -26,7 +28,7 @@ def get_route_model_param(route_handler: RouteHandler, model: Type[M]) -> Tuple[
     return params[0].name, params[0].annotation
 
 
-def calculate_hash(path: Path, chunk_size: int = 5_242_880) -> str:
+def calculate_hash(path: Path, chunk_size: Size = Size(5, SizeUnit.MiB)) -> str:
     """Calculate SHA256 hash of a file."""
     package_hash = sha256()
 

--- a/questionpy_server/web.py
+++ b/questionpy_server/web.py
@@ -13,6 +13,7 @@ from aiohttp.web_response import Response
 from pydantic import BaseModel, ValidationError
 
 from questionpy_common import constants
+from questionpy_common.misc import Size, SizeUnit
 
 from questionpy_server.api.models import PackageQuestionStateNotFound, QuestionStateHash
 from questionpy_server.cache import SizeError, FileLimitLRU
@@ -68,16 +69,16 @@ class HashContainer(NamedTuple):
 
 
 @overload
-async def read_part(part: BodyPartReader, max_size: int, calculate_hash: Literal[True]) -> HashContainer:
+async def read_part(part: BodyPartReader, max_size: Size, calculate_hash: Literal[True]) -> HashContainer:
     ...
 
 
 @overload
-async def read_part(part: BodyPartReader, max_size: int, calculate_hash: Literal[False]) -> bytes:
+async def read_part(part: BodyPartReader, max_size: Size, calculate_hash: Literal[False]) -> bytes:
     ...
 
 
-async def read_part(part: BodyPartReader, max_size: int, calculate_hash: bool = False) -> Union[HashContainer, bytes]:
+async def read_part(part: BodyPartReader, max_size: Size, calculate_hash: bool = False) -> Union[HashContainer, bytes]:
     """
     Reads a body part of a multipart/form-data request.
 
@@ -92,11 +93,11 @@ async def read_part(part: BodyPartReader, max_size: int, calculate_hash: bool = 
 
     size = 0
 
-    while chunk := await part.read_chunk(size=262_144):
+    while chunk := await part.read_chunk(size=Size(256, SizeUnit.KiB)):
         # Check if size limit is exceeded.
         size += len(chunk)
         if size > max_size:
-            msg = f"Size limit of {max_size} bytes exceeded for field '{part.name}'"
+            msg = f"Size limit of {max_size} exceeded for field '{part.name}'"
             web_logger.warning(msg)
             raise HTTPRequestEntityTooLarge(text=msg, max_size=max_size, actual_size=size)
 
@@ -130,9 +131,9 @@ async def parse_form_data(request: Request) \
             continue
 
         if part.name == 'main':
-            main = await read_part(part, server.settings.webservice.max_bytes_main, calculate_hash=False)
+            main = await read_part(part, server.settings.webservice.max_main_size, calculate_hash=False)
         elif part.name == 'package':
-            package = await read_part(part, server.settings.webservice.max_bytes_package, calculate_hash=True)
+            package = await read_part(part, server.settings.webservice.max_package_size, calculate_hash=True)
         elif part.name == 'question_state':
             question_state = await read_part(part, constants.MAX_BYTES_QUESTION_STATE, calculate_hash=True)
 
@@ -338,7 +339,7 @@ def ensure_package_exists(_func: Optional[RouteHandler] = None, required_hash: b
                 if not isinstance(part, BodyPartReader):
                     continue
                 if part.name == 'package':
-                    package_container = await read_part(part, server.settings.webservice.max_bytes_package,
+                    package_container = await read_part(part, server.settings.webservice.max_package_size,
                                                         calculate_hash=True)
                     break
 

--- a/tests/collector/test_indexer.py
+++ b/tests/collector/test_indexer.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 from questionpy_common.manifest import Manifest
+from questionpy_common.misc import Size, SizeUnit
 
 from questionpy_server import WorkerPool
 from questionpy_server.collector.abc import BaseCollector
@@ -19,7 +20,7 @@ from tests.conftest import PACKAGE
 @pytest.mark.parametrize('kind', [PACKAGE.path, PACKAGE.manifest])
 @patch('questionpy_server.collector.lms_collector.LMSCollector', spec=LMSCollector)
 async def test_register_package_with_path_and_manifest(collector: LMSCollector, kind: Union[Path, Manifest]) -> None:
-    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
+    indexer = Indexer(WorkerPool(1, Size(200, SizeUnit.MiB)))
     await indexer.register_package(PACKAGE.hash, kind, collector)
 
     # Package is accessible by hash.
@@ -31,7 +32,7 @@ async def test_register_package_with_path_and_manifest(collector: LMSCollector, 
 
 @patch('questionpy_server.collector.lms_collector.LMSCollector', spec=LMSCollector)
 async def test_register_package_from_lms(collector: LMSCollector) -> None:
-    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
+    indexer = Indexer(WorkerPool(1, Size(200, SizeUnit.MiB)))
     await indexer.register_package(PACKAGE.hash, PACKAGE.manifest, collector)
 
     # Package is not accessible by name and version.
@@ -52,7 +53,7 @@ async def test_register_package_from_local_and_repo_collector(collector: BaseCol
     # Create mock.
     collector = patch(collector.__module__, spec=collector).start()
 
-    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
+    indexer = Indexer(WorkerPool(1, Size(200, SizeUnit.MiB)))
     await indexer.register_package(PACKAGE.hash, PACKAGE.manifest, collector)
 
     # Package is accessible by hash.
@@ -78,7 +79,7 @@ async def test_register_package_from_local_and_repo_collector(collector: BaseCol
 
 
 async def test_register_package_with_same_hash_as_existing_package() -> None:
-    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
+    indexer = Indexer(WorkerPool(1, Size(200, SizeUnit.MiB)))
 
     # Register package from local collector.
     local_collector = patch(LocalCollector.__module__, spec=LocalCollector).start()
@@ -113,7 +114,7 @@ async def test_register_two_packages_with_same_manifest_but_different_hashes(cap
     collector = patch(LocalCollector.__module__, spec=LocalCollector).start()
 
     # Register a package.
-    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
+    indexer = Indexer(WorkerPool(1, Size(200, SizeUnit.MiB)))
     await indexer.register_package(PACKAGE.hash, PACKAGE.manifest, collector)
 
     with caplog.at_level(logging.WARNING):
@@ -126,7 +127,7 @@ async def test_register_two_packages_with_same_manifest_but_different_hashes(cap
 
 
 async def test_unregister_package_with_lms_source() -> None:
-    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
+    indexer = Indexer(WorkerPool(1, Size(200, SizeUnit.MiB)))
     collector = patch(LMSCollector.__module__, spec=LMSCollector).start()
     await indexer.register_package(PACKAGE.hash, PACKAGE.manifest, collector)
 
@@ -139,7 +140,7 @@ async def test_unregister_package_with_lms_source() -> None:
 
 @pytest.mark.parametrize('collector', [LocalCollector, RepoCollector])
 async def test_unregister_package_with_local_and_repo_source(collector: BaseCollector) -> None:
-    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
+    indexer = Indexer(WorkerPool(1, Size(200, SizeUnit.MiB)))
     collector = patch(collector.__module__, spec=collector).start()
     await indexer.register_package(PACKAGE.hash, PACKAGE.manifest, collector)
 
@@ -159,7 +160,7 @@ async def test_unregister_package_with_local_and_repo_source(collector: BaseColl
 
 
 async def test_unregister_package_with_multiple_sources() -> None:
-    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
+    indexer = Indexer(WorkerPool(1, Size(200, SizeUnit.MiB)))
 
     # Register package from local, repo, and LMS collector.
     lms_collector = patch(LMSCollector.__module__, spec=LMSCollector).start()

--- a/tests/collector/test_lms_collector.py
+++ b/tests/collector/test_lms_collector.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 import pytest
 from _pytest.tmpdir import TempPathFactory
+from questionpy_common.misc import Size, SizeUnit
 
 from questionpy_server import WorkerPool
 from questionpy_server.cache import FileLimitLRU
@@ -21,13 +22,13 @@ def create_lms_collector(tmp_path_factory: TempPathFactory) -> tuple[LMSCollecto
     """
 
     path = tmp_path_factory.mktemp('qpy')
-    cache = FileLimitLRU(path, 20 * 1024 * 1024, extension='.qpy')
-    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
+    cache = FileLimitLRU(path, Size(20, SizeUnit.KiB), extension='.qpy')
+    indexer = Indexer(WorkerPool(1, Size(200, SizeUnit.MiB)))
     return LMSCollector(cache, indexer), cache
 
 
 async def test_package_in_cache_before_init(tmp_path_factory: TempPathFactory) -> None:
-    cache = FileLimitLRU(tmp_path_factory.mktemp('qpy'), 20 * 1024 * 1024, extension='.qpy')
+    cache = FileLimitLRU(tmp_path_factory.mktemp('qpy'), Size(20, SizeUnit.KiB), extension='.qpy')
 
     # Put package into cache.
     await cache.put(PACKAGE.hash, PACKAGE.path.read_bytes())

--- a/tests/collector/test_local_collector.py
+++ b/tests/collector/test_local_collector.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 from _pytest.tmpdir import TempPathFactory
+from questionpy_common.misc import Size, SizeUnit
 
 from questionpy_server.package import Package
 from questionpy_server.worker.controller import WorkerPool
@@ -22,7 +23,7 @@ def create_local_collector(tmp_path_factory: TempPathFactory) -> tuple[LocalColl
     """
 
     path = tmp_path_factory.mktemp('qpy')
-    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
+    indexer = Indexer(WorkerPool(1, Size(200, SizeUnit.MiB)))
     return LocalCollector(path, indexer), path
 
 
@@ -32,7 +33,7 @@ async def test_ignore_files_with_wrong_extension(tmp_path_factory: TempPathFacto
     ignore_file = directory / 'wrong.extension'
     ignore_file.touch()
 
-    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
+    indexer = Indexer(WorkerPool(1, Size(200, SizeUnit.MiB)))
     local_collector = LocalCollector(directory, indexer)
 
     async with local_collector:
@@ -48,7 +49,7 @@ async def test_ignore_files_with_wrong_extension(tmp_path_factory: TempPathFacto
 
 async def test_package_exists_before_init(tmp_path_factory: TempPathFactory) -> None:
     path = tmp_path_factory.mktemp('qpy')
-    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
+    indexer = Indexer(WorkerPool(1, Size(200, SizeUnit.MiB)))
     local_collector = LocalCollector(path, indexer)
 
     package_path = copy(PACKAGE.path, path)
@@ -199,7 +200,7 @@ async def test_package_gets_moved_to_different_folder(tmp_path_factory: TempPath
         # Use new_directory as the directory to be watched and directory to be the new directory of the package.
         directory, new_directory = new_directory, directory
 
-    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
+    indexer = Indexer(WorkerPool(1, Size(200, SizeUnit.MiB)))
     local_collector = LocalCollector(directory, indexer)
 
     # Create a package in the directory.

--- a/tests/collector/test_package_collection.py
+++ b/tests/collector/test_package_collection.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, Mock
 
 import pytest
 from _pytest.tmpdir import TempPathFactory
+from questionpy_common.misc import Size
 
 from questionpy_server.cache import FileLimitLRU
 from questionpy_server.collector import PackageCollection
@@ -87,7 +88,7 @@ def test_get_packages() -> None:
 
 
 async def test_notify_indexer_on_cache_deletion(tmp_path_factory: TempPathFactory) -> None:
-    cache = FileLimitLRU(tmp_path_factory.mktemp('qpy'), 100)
+    cache = FileLimitLRU(tmp_path_factory.mktemp('qpy'), Size(100))
     PackageCollection(None, [], cache, Mock())
 
     # The callback should unregister the package from the indexer.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from aiohttp.pytest_plugin import AiohttpClient
 from aiohttp.test_utils import TestClient
 
 from questionpy_common.manifest import Manifest
+from questionpy_common.misc import Size, SizeUnit
 
 from questionpy_server.app import QPyServer
 from questionpy_server.settings import Settings, WebserviceSettings, PackageCacheSettings, CollectorSettings, \
@@ -22,7 +23,7 @@ from questionpy_server.settings import Settings, WebserviceSettings, PackageCach
 def get_file_hash(path: Path) -> str:
     hash_value = sha256()
     with path.open('rb') as file:
-        while chunk := file.read(4096):
+        while chunk := file.read(Size(4, SizeUnit.KiB)):
             hash_value.update(chunk)
     return hash_value.hexdigest()
 
@@ -54,7 +55,7 @@ def qpy_server(tmp_path_factory: TempPathFactory) -> QPyServer:
     server = QPyServer(Settings(
         config_files=(),
         webservice=WebserviceSettings(listen_address="127.0.0.1", listen_port=0),
-        worker=WorkerSettings(max_workers=8, max_memory=524_288_000),
+        worker=WorkerSettings(),
         cache_package=PackageCacheSettings(directory=package_cache_directory),
         cache_question_state=QuestionStateCacheSettings(directory=question_state_cache_directory),
         collector=CollectorSettings()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -8,22 +8,23 @@ from unittest.mock import patch
 
 import pytest
 from _pytest.tmpdir import TempPathFactory
+from questionpy_common.misc import Size
 
 from questionpy_server.cache import FileLimitLRU, SizeError
 
 
 @dataclass
 class ItemSettings:
-    bytes_per_item: int
+    size_per_item: Size
     num_of_items: int
 
     def __post_init__(self) -> None:
-        self.list = [(char, self.bytes_per_item * char.encode()) for char in ascii_lowercase[:self.num_of_items]]
-        self.total_bytes = self.bytes_per_item * self.num_of_items
+        self.list = [(char, self.size_per_item * char.encode()) for char in ascii_lowercase[:self.num_of_items]]
+        self.total_size = Size(self.size_per_item * self.num_of_items)
 
 
 class CacheSettings(NamedTuple):
-    max_bytes: int
+    size: Size
     directory: Path
 
 
@@ -36,11 +37,11 @@ class Settings(NamedTuple):
 def settings(tmp_path_factory: TempPathFactory) -> Settings:
     return Settings(
         cache=CacheSettings(
-            max_bytes=100,
+            size=Size(100),
             directory=tmp_path_factory.mktemp('qpy'),
         ),
         items=ItemSettings(
-            bytes_per_item=15,
+            size_per_item=Size(15),
             num_of_items=6
         )
     )
@@ -70,15 +71,15 @@ def get_file_count(directory: Path) -> int:
     return len(list(file for file in directory.iterdir() if file.is_file()))
 
 
-def get_directory_size(directory: str) -> int:
+def get_directory_size(directory: str) -> Size:
     """
     Calculates directory size.
 
     :param directory: of which to get the size
-    :return: size of directory in bytes
+    :return: size of directory
     """
 
-    return sum(file.stat().st_size for file in Path(directory).iterdir() if file.is_file())
+    return Size(sum(file.stat().st_size for file in Path(directory).iterdir() if file.is_file()))
 
 
 @pytest.fixture
@@ -87,7 +88,7 @@ def path_with_too_many_bytes(tmp_path_factory: TempPathFactory, settings: Settin
     write_files_to_directory(settings.items.list, directory)
 
     large_item_path = directory / 'large_item'
-    large_item_path.write_bytes(b'.' * (settings.cache.max_bytes - settings.items.total_bytes + 1))
+    large_item_path.write_bytes(b'.' * (settings.cache.size - settings.items.total_size + 1))
 
     return directory
 
@@ -95,30 +96,30 @@ def path_with_too_many_bytes(tmp_path_factory: TempPathFactory, settings: Settin
 @pytest.fixture
 def cache(settings: Settings) -> FileLimitLRU:
     write_files_to_directory(settings.items.list, Path(settings.cache.directory))
-    return FileLimitLRU(settings.cache.directory, settings.cache.max_bytes)
+    return FileLimitLRU(settings.cache.directory, settings.cache.size)
 
 
 def test_init(cache: FileLimitLRU, settings: Settings, path_with_too_many_bytes: Path) -> None:
-    assert cache.total_bytes == settings.items.total_bytes
-    assert cache.space_left == settings.cache.max_bytes - settings.items.total_bytes
+    assert cache.total_size == settings.items.total_size
+    assert cache.space_left == settings.cache.size - settings.items.total_size
     assert get_file_count(settings.cache.directory) == settings.items.num_of_items
 
     # Existing path contains more bytes than the cache can hold.
-    small_cache = FileLimitLRU(path_with_too_many_bytes, settings.cache.max_bytes)
-    assert small_cache.total_bytes <= settings.cache.max_bytes
-    assert get_directory_size(str(path_with_too_many_bytes)) <= settings.cache.max_bytes
+    small_cache = FileLimitLRU(path_with_too_many_bytes, settings.cache.size)
+    assert small_cache.total_size <= settings.cache.size
+    assert get_directory_size(str(path_with_too_many_bytes)) <= settings.cache.size
 
     # Ignore directories.
     (Path(settings.cache.directory) / "test_dir").mkdir()
-    FileLimitLRU(settings.cache.directory, settings.cache.max_bytes)
+    FileLimitLRU(settings.cache.directory, settings.cache.size)
 
     # Remove files with temporary extension.
     tmp_file = Path(settings.cache.directory) / ("file.txt" + cache._tmp_extension)
     tmp_file.write_bytes(b'.')
-    new_cache = FileLimitLRU(settings.cache.directory, settings.cache.max_bytes)
+    new_cache = FileLimitLRU(settings.cache.directory, settings.cache.size)
     assert not tmp_file.is_file()
     assert get_file_count(settings.cache.directory) == settings.items.num_of_items
-    assert new_cache.total_bytes == settings.items.total_bytes
+    assert new_cache.total_size == settings.items.total_size
 
 
 async def test_remove(cache: FileLimitLRU, settings: Settings) -> None:
@@ -126,27 +127,27 @@ async def test_remove(cache: FileLimitLRU, settings: Settings) -> None:
     file, _ = settings.items.list[0]
     await cache.remove(file)
     assert not (cache.directory / file).is_file()
-    expected_total_bytes = settings.items.total_bytes - settings.items.bytes_per_item
-    assert cache.total_bytes == expected_total_bytes
+    expected_total_size = settings.items.total_size - settings.items.size_per_item
+    assert cache.total_size == expected_total_size
 
     # Removing a file should fire the callback.
     with patch.object(cache, 'on_remove') as mock:
         file, _ = settings.items.list[-1]
         await cache.remove(file)
-        expected_total_bytes = settings.items.total_bytes - 2 * settings.items.bytes_per_item
+        expected_total_size = settings.items.total_size - 2 * settings.items.size_per_item
         assert not (cache.directory / file).is_file()
-        assert cache.total_bytes == expected_total_bytes
+        assert cache.total_size == expected_total_size
         mock.assert_called_once()
 
     # Remove previously removed file.
     with pytest.raises(FileNotFoundError):
         await cache.remove(file)
-    assert cache.total_bytes == expected_total_bytes
+    assert cache.total_size == expected_total_size
 
     # Remove not existing file.
     with pytest.raises(FileNotFoundError):
         await cache.remove('doesnotexist')
-    assert cache.total_bytes == expected_total_bytes
+    assert cache.total_size == expected_total_size
 
 
 def test_get(cache: FileLimitLRU, settings: Settings) -> None:
@@ -184,25 +185,25 @@ async def test_put(cache: FileLimitLRU, settings: Settings) -> None:
     # Content type is not bytes.
     with pytest.raises(TypeError):
         await cache.put('new', 'string')  # type: ignore[arg-type]
-    assert cache.total_bytes == settings.items.total_bytes
+    assert cache.total_size == settings.items.total_size
     assert get_file_count(settings.cache.directory) == settings.items.num_of_items
 
     # Content size is bigger than cache size.
     with pytest.raises(SizeError):
-        await cache.put('new', b'.' * (settings.cache.max_bytes + 1))
+        await cache.put('new', b'.' * (settings.cache.size + 1))
 
     # Replace existing file.
     file, _ = settings.items.list[0]
-    new_content = b'.' * settings.items.bytes_per_item
+    new_content = b'.' * settings.items.size_per_item
     await cache.put(file, new_content)
     assert (Path(settings.cache.directory) / file).read_bytes() == new_content
-    assert cache.total_bytes == settings.items.total_bytes
+    assert cache.total_size == settings.items.total_size
 
     # Put max sized content into cache.
-    file, content = 'A', b'.' * settings.cache.max_bytes
+    file, content = 'A', b'.' * settings.cache.size
     await cache.put(file, content)
     assert (Path(settings.cache.directory) / file).is_file()
-    assert cache.total_bytes == settings.cache.max_bytes
+    assert cache.total_size == settings.cache.size
     assert get_file_count(settings.cache.directory) == 1
 
     # Partially written file raises error.
@@ -216,7 +217,7 @@ async def test_put(cache: FileLimitLRU, settings: Settings) -> None:
 
     # Remove the oldest file in cache.
     filecount = 3
-    datasize = settings.cache.max_bytes // filecount
+    datasize = settings.cache.size // filecount
     files, content = [str(i) for i in range(filecount)], b'.' * datasize
 
     for file in files:
@@ -227,8 +228,8 @@ async def test_put(cache: FileLimitLRU, settings: Settings) -> None:
         new_file = str(filecount + i + 1)
         await cache.put(new_file, content)
 
-        assert cache.total_bytes == datasize * filecount
-        assert cache.total_bytes <= settings.cache.max_bytes
+        assert cache.total_size == datasize * filecount
+        assert cache.total_size <= settings.cache.size
         assert get_file_count(settings.cache.directory) == filecount
         assert (Path(settings.cache.directory) / new_file).is_file()
         assert not (Path(settings.cache.directory) / files[i]).is_file()


### PR DESCRIPTION
Beim Einlesen von Bytes in der `config.ini` wird nun `Size.from_string()` und beim Arbeiten/Ausgeben von Bytes `Size` verwendet (s. questionpy-org/questionpy-common#5). 