### PR TITLE
Ersetze sleeps in Local Collector Tests

### DIFF
--- a/tests/collector/test_local_collector.py
+++ b/tests/collector/test_local_collector.py
@@ -1,8 +1,10 @@
-from asyncio import sleep
+from asyncio import get_running_loop, sleep, wait_for
 from pathlib import Path
 from shutil import copy
+from typing import Callable
 from unittest.mock import patch
 
+import asyncio
 import pytest
 from _pytest.tmpdir import TempPathFactory
 
@@ -24,6 +26,34 @@ def create_local_collector(tmp_path_factory: TempPathFactory) -> tuple[LocalColl
     path = tmp_path_factory.mktemp('qpy')
     indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
     return LocalCollector(path, indexer), path
+
+
+class WaitForAsyncFunctionCall:
+    def __init__(self, func: Callable):
+        """
+        Wrapper around a function that is being watched.
+
+        :param func: Function to wait for.
+        """
+        self.func = func
+        self.fut = get_running_loop().create_future()
+
+    async def wrap(self, *args, **kwargs):  # type: ignore
+        """Method to pass as side_effect to patch(.object)."""
+        ret = await self.func(*args, **kwargs)
+        self.fut.set_result(True)
+        return ret
+
+    async def wait_for_fn_call(self, timeout: float) -> None:
+        """
+        Wait until the function has been called.
+
+        :param timeout: Maximum time to wait (in seconds).
+        """
+        try:
+            await wait_for(self.fut, timeout)
+        except asyncio.TimeoutError:
+            pytest.fail(f"Function {self.func} has not been called within {timeout} seconds.", False)
 
 
 async def test_ignore_files_with_wrong_extension(tmp_path_factory: TempPathFactory) -> None:
@@ -66,13 +96,14 @@ async def test_package_gets_created(tmp_path_factory: TempPathFactory) -> None:
     local_collector, directory = create_local_collector(tmp_path_factory)
 
     async with local_collector:
-        with patch.object(local_collector.indexer, 'register_package') as mock_register:
+        register = WaitForAsyncFunctionCall(local_collector.indexer.register_package)
+        with patch.object(local_collector.indexer, 'register_package', side_effect=register.wrap) as mock_register:
 
             # Copy a package to the directory.
             package_path = Path(copy(PACKAGE.path, directory))
             package = Package(PACKAGE.hash, PACKAGE.manifest)
 
-            await sleep(0.5)
+            await register.wait_for_fn_call(10)
 
             # Package got registered in the indexer and local collector.
             mock_register.assert_awaited_with(package.hash, package_path, local_collector)
@@ -87,12 +118,16 @@ async def test_package_gets_modified(tmp_path_factory: TempPathFactory) -> None:
     package_1 = Package(PACKAGE_2.hash, PACKAGE_2.manifest)
 
     async with local_collector:
-        with patch.object(local_collector.indexer, 'register_package') as mock_register, \
-             patch.object(local_collector.indexer, 'unregister_package') as mock_unregister:
+        register = WaitForAsyncFunctionCall(local_collector.indexer.register_package)
+        unregister = WaitForAsyncFunctionCall(local_collector.indexer.unregister_package)
+        with patch.object(local_collector.indexer, 'register_package', side_effect=register.wrap) as mock_register, \
+             patch.object(local_collector.indexer, 'unregister_package',
+                          side_effect=unregister.wrap) as mock_unregister:
 
             # Modify the package.
             package_path.write_bytes(PACKAGE_2.path.read_bytes())
-            await sleep(0.5)
+            await register.wait_for_fn_call(10)
+            await unregister.wait_for_fn_call(10)
 
             # Old package got unregistered and the new one registered in the indexer and local collector.
             mock_register.assert_awaited_with(package_1.hash, package_path, local_collector)
@@ -111,10 +146,12 @@ async def test_package_gets_deleted(tmp_path_factory: TempPathFactory) -> None:
     package = Package(PACKAGE.hash, PACKAGE.manifest)
 
     async with local_collector:
-        with patch.object(local_collector.indexer, 'unregister_package') as mock_unregister:
+        unregister = WaitForAsyncFunctionCall(local_collector.indexer.unregister_package)
+        with patch.object(local_collector.indexer, 'unregister_package',
+                          side_effect=unregister.wrap) as mock_unregister:
             # Remove package from the directory.
             package_path.unlink()
-            await sleep(0.5)
+            await unregister.wait_for_fn_call(10)
 
             # Package got unregistered in the indexer and local collector.
             mock_unregister.assert_awaited_with(package.hash, local_collector)
@@ -155,10 +192,11 @@ async def test_package_gets_moved_from_non_package_to_package(tmp_path_factory: 
     package = Package(PACKAGE.hash, PACKAGE.manifest)
 
     async with local_collector:
-        with patch.object(local_collector.indexer, 'register_package') as mock_register:
+        register = WaitForAsyncFunctionCall(local_collector.indexer.register_package)
+        with patch.object(local_collector.indexer, 'register_package', side_effect=register.wrap) as mock_register:
             # Rename the package.
             src_path.rename(dest_path)
-            await sleep(0.5)
+            await register.wait_for_fn_call(10)
 
             # Package got registered in the indexer and local collector.
             mock_register.assert_awaited_with(package.hash, dest_path, local_collector)
@@ -174,10 +212,12 @@ async def test_package_gets_moved_from_package_to_non_package(tmp_path_factory: 
     package = Package(PACKAGE.hash, PACKAGE.manifest)
 
     async with local_collector:
-        with patch.object(local_collector.indexer, 'unregister_package') as mock_unregister:
+        unregister = WaitForAsyncFunctionCall(local_collector.indexer.unregister_package)
+        with patch.object(local_collector.indexer, 'unregister_package',
+                          side_effect=unregister.wrap) as mock_unregister:
             # Rename the package.
             Path(src_path).rename(dest_path)
-            await sleep(0.5)
+            await unregister.wait_for_fn_call(10)
 
             # Package got unregistered in the indexer and local collector.
             mock_unregister.assert_awaited_with(package.hash, local_collector)
@@ -207,10 +247,12 @@ async def test_package_gets_moved_to_different_folder(tmp_path_factory: TempPath
     package = Package(PACKAGE.hash, PACKAGE.manifest)
 
     async with local_collector:
-        with patch.object(local_collector.indexer, 'unregister_package') as mock_unregister:
+        unregister = WaitForAsyncFunctionCall(local_collector.indexer.unregister_package)
+        with patch.object(local_collector.indexer, 'unregister_package',
+                          side_effect=unregister.wrap) as mock_unregister:
             # Move the package.
             src_path.rename(new_directory / src_path.name)
-            await sleep(1)
+            await unregister.wait_for_fn_call(10)
 
             # Package got unregistered in the indexer and local collector.
             mock_unregister.assert_awaited_with(package.hash, local_collector)

--- a/tests/collector/test_local_collector.py
+++ b/tests/collector/test_local_collector.py
@@ -38,11 +38,14 @@ class WaitForAsyncFunctionCall:
         self.func = func
         self.fut = get_running_loop().create_future()
 
-    async def wrap(self, *args, **kwargs):  # type: ignore
+    async def wrap(self, *args: Any, **kwargs: Any) -> Any:
         """Method to pass as side_effect to patch(.object)."""
-        ret = await self.func(*args, **kwargs)
-        self.fut.set_result(True)
-        return ret
+        try:
+            ret = await self.func(*args, **kwargs)
+            self.fut.set_result(True)
+            return ret
+        except Exception as e:  # pylint: disable=broad-except
+            self.fut.set_exception(e)
 
     async def wait_for_fn_call(self, timeout: float) -> None:
         """

--- a/tests/collector/test_local_collector.py
+++ b/tests/collector/test_local_collector.py
@@ -1,7 +1,7 @@
 from asyncio import get_running_loop, sleep, wait_for
 from pathlib import Path
 from shutil import copy
-from typing import Callable
+from typing import Any, Callable
 from unittest.mock import patch
 
 import asyncio


### PR DESCRIPTION
Mit diesen Änderungen werden die Aufrufe von `sleep` ersetzt, damit die Tests auf langsamen/überlasteten CPUs nicht scheitern. Das ist leider nicht die erhoffte Lösung für die sporadisch scheiternden Github Actions, aber ich habe in #35 herausgefunden, was das Problem ist.