### PR TITLE
feat: work with snapshots instead of system events in local collector

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1003,8 +1003,8 @@ pydantic-factories = "^1.6.2"
 [package.source]
 type = "git"
 url = "https://github.com/questionpy-org/questionpy-common.git"
-reference = "ff24942"
-resolved_reference = "ff2494213ac6e130e93b3eb9bc99e7de2293b360"
+reference = "07ca576"
+resolved_reference = "07ca576b4497a9c50b3a2d9d9db5cef98af7b652"
 
 [[package]]
 name = "six"
@@ -1327,4 +1327,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "8fb4d06fe2340dc21222ee24c1663d69bda00acf5c5b77a712b9ffd885670692"
+content-hash = "66304f13404d5d6d4fda5de200a3defb81db4feeb3ad41246cf0266ecab3f0a6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ python = "^3.9"
 aiohttp = "^3.8.1"
 pydantic = "^1.9.1"
 questionpy-common = { git = "https://github.com/questionpy-org/questionpy-common.git", rev = "07ca576" }
-watchdog = "^2.2.0"
+watchdog = "^2.2.1"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.14.5"

--- a/questionpy_server/collector/local_collector.py
+++ b/questionpy_server/collector/local_collector.py
@@ -206,7 +206,8 @@ class LocalCollector(BaseCollector):
 
         # If no snapshot exists, use EmptyDirectorySnapshot to get all files as created.
         old_snapshot = self._snapshot or EmptyDirectorySnapshot()
-        new_snapshot = DirectorySnapshot(str(self.directory), recursive=False, listdir=directory_iterator)
+        new_snapshot = await to_thread(DirectorySnapshot, str(self.directory), recursive=False,
+                                       listdir=directory_iterator)
         difference = DirectorySnapshotDiff(old_snapshot, new_snapshot)
 
         for path in difference.files_created:

--- a/questionpy_server/collector/local_collector.py
+++ b/questionpy_server/collector/local_collector.py
@@ -226,7 +226,7 @@ class LocalCollector(BaseCollector):
                               "currently read by a worker.", package_path)
 
         # Replace paths for moved packages.
-        paths = list(map(lambda files: (Path(files[0]), Path(files[1])), difference.files_moved))
+        paths = [(Path(old_path), Path(new_path)) for old_path, new_path in difference.files_moved]
         self.map.replace(paths)
 
         # Update the snapshot.

--- a/questionpy_server/collector/local_collector.py
+++ b/questionpy_server/collector/local_collector.py
@@ -178,12 +178,10 @@ class LocalCollector(BaseCollector):
             :param pkg_path: The path of the package.
             """
 
-            pkg_hash = self.map.pop(pkg_path)
-            if not pkg_hash:
+            if not (pkg_hash := self.map.pop(pkg_path)):
                 return
-            packages = self.map.get(pkg_hash)
-            if packages is None or len(packages) == 0:
-                # There is no other package with the same hash - unregister it.
+            if not (packages := self.map.get(pkg_hash)) or len(packages) == 0:
+                # There are no other packages with the same hash - unregister it.
                 await self.indexer.unregister_package(pkg_hash, self)
 
         if not self._lock:
@@ -218,13 +216,11 @@ class LocalCollector(BaseCollector):
             entries = []
             for old_path, new_path in difference.files_moved:
                 # Remove old path and save the package hash.
-                existing_hash = self.map.pop(Path(old_path))
-                if existing_hash:
+                if existing_hash := self.map.pop(Path(old_path)):
                     entries.append((existing_hash, Path(new_path)))
             for entry in entries:
                 # Insert package hash with new path.
-                existing_hash, new_path = entry
-                self.map.insert(existing_hash, new_path)
+                self.map.insert(*entry)
 
             # Update the snapshot.
             self._snapshot = new_snapshot

--- a/questionpy_server/collector/local_collector.py
+++ b/questionpy_server/collector/local_collector.py
@@ -61,7 +61,9 @@ class PathToHash:
             return self.paths.get(key)
 
         if isinstance(key, str):
-            return self.hashes.get(key)
+            if paths := self.hashes.get(key):
+                return paths.copy()
+            return None
 
         raise TypeError(f'Expected Path or str, got {type(key)}')
 

--- a/tests/collector/test_local_collector.py
+++ b/tests/collector/test_local_collector.py
@@ -277,7 +277,11 @@ async def test_package_filenames_get_swapped(tmp_path_factory: TempPathFactory) 
         with patch.object(local_collector.indexer, 'register_package') as mock_register, \
              patch.object(local_collector.indexer, 'unregister_package') as mock_unregister:
             # Swap the package filenames.
-            package_1_path, package_2_path = package_2_path, package_1_path
+            temporary_path = directory / 'temporary_path'
+            package_1_path.rename(temporary_path)
+            package_2_path.rename(package_1_path)
+            temporary_path.rename(package_2_path)
+
             await local_collector.update()
 
             # The packages should be swapped in the local collector.

--- a/tests/collector/test_local_collector.py
+++ b/tests/collector/test_local_collector.py
@@ -1,6 +1,8 @@
-from asyncio import get_running_loop, sleep, wait_for
+from asyncio import get_running_loop, wait_for, sleep
+from os import kill, getpid
 from pathlib import Path
 from shutil import copy
+from signal import SIGUSR1
 from typing import Any, Callable
 from unittest.mock import patch
 
@@ -59,6 +61,21 @@ class WaitForAsyncFunctionCall:
             pytest.fail(f"Function {self.func} has not been called within {timeout} seconds.", False)
 
 
+async def test_run_update_on_signal(tmp_path_factory: TempPathFactory) -> None:
+    local_collector, directory = create_local_collector(tmp_path_factory)
+
+    async with local_collector:
+        # Check that the update function is called on SIGUSR1.
+        with patch.object(local_collector, 'update') as mock_update:
+            # Wait for signal handler to be set up.
+            await sleep(0.5)
+            # Send signal.
+            kill(getpid(), SIGUSR1)
+            # Wait for signal handler to be called.
+            await sleep(0.5)
+            mock_update.assert_awaited_once()
+
+
 async def test_ignore_files_with_wrong_extension(tmp_path_factory: TempPathFactory) -> None:
     # File exists before initializing.
     directory = tmp_path_factory.mktemp('qpy')
@@ -98,18 +115,16 @@ async def test_package_exists_before_init(tmp_path_factory: TempPathFactory) -> 
 async def test_package_gets_created(tmp_path_factory: TempPathFactory) -> None:
     local_collector, directory = create_local_collector(tmp_path_factory)
 
-    async with local_collector:
-        register = WaitForAsyncFunctionCall(local_collector.indexer.register_package)
-        with patch.object(local_collector.indexer, 'register_package', side_effect=register.wrap) as mock_register:
+    package = Package(PACKAGE.hash, PACKAGE.manifest)
 
+    async with local_collector:
+        with patch.object(local_collector.indexer, 'register_package') as mock_register:
             # Copy a package to the directory.
             package_path = Path(copy(PACKAGE.path, directory))
-            package = Package(PACKAGE.hash, PACKAGE.manifest)
-
-            await register.wait_for_fn_call(10)
+            await local_collector.update()
 
             # Package got registered in the indexer and local collector.
-            mock_register.assert_awaited_with(package.hash, package_path, local_collector)
+            mock_register.assert_awaited_once_with(package.hash, package_path, local_collector)
             assert package_path == await local_collector.get_path(package)
 
 
@@ -117,28 +132,23 @@ async def test_package_gets_modified(tmp_path_factory: TempPathFactory) -> None:
     local_collector, directory = create_local_collector(tmp_path_factory)
 
     package_path = Path(copy(PACKAGE.path, directory))
-    package_0 = Package(PACKAGE.hash, PACKAGE.manifest)
-    package_1 = Package(PACKAGE_2.hash, PACKAGE_2.manifest)
+    package_1 = Package(PACKAGE.hash, PACKAGE.manifest)
+    package_2 = Package(PACKAGE_2.hash, PACKAGE_2.manifest)
 
     async with local_collector:
-        register = WaitForAsyncFunctionCall(local_collector.indexer.register_package)
-        unregister = WaitForAsyncFunctionCall(local_collector.indexer.unregister_package)
-        with patch.object(local_collector.indexer, 'register_package', side_effect=register.wrap) as mock_register, \
-             patch.object(local_collector.indexer, 'unregister_package',
-                          side_effect=unregister.wrap) as mock_unregister:
-
+        with patch.object(local_collector.indexer, 'register_package') as mock_register, \
+             patch.object(local_collector.indexer, 'unregister_package') as mock_unregister:
             # Modify the package.
             package_path.write_bytes(PACKAGE_2.path.read_bytes())
-            await register.wait_for_fn_call(10)
-            await unregister.wait_for_fn_call(10)
+            await local_collector.update()
 
             # Old package got unregistered and the new one registered in the indexer and local collector.
-            mock_register.assert_awaited_with(package_1.hash, package_path, local_collector)
-            mock_unregister.assert_awaited_with(package_0.hash, local_collector)
+            mock_register.assert_awaited_once_with(package_2.hash, package_path, local_collector)
+            mock_unregister.assert_awaited_once_with(package_1.hash, local_collector)
 
             with pytest.raises(FileNotFoundError):
-                await local_collector.get_path(package_0)
-            assert Path(package_path) == await local_collector.get_path(package_1)
+                await local_collector.get_path(package_1)
+            assert Path(package_path) == await local_collector.get_path(package_2)
 
 
 async def test_package_gets_deleted(tmp_path_factory: TempPathFactory) -> None:
@@ -149,15 +159,13 @@ async def test_package_gets_deleted(tmp_path_factory: TempPathFactory) -> None:
     package = Package(PACKAGE.hash, PACKAGE.manifest)
 
     async with local_collector:
-        unregister = WaitForAsyncFunctionCall(local_collector.indexer.unregister_package)
-        with patch.object(local_collector.indexer, 'unregister_package',
-                          side_effect=unregister.wrap) as mock_unregister:
+        with patch.object(local_collector.indexer, 'unregister_package') as mock_unregister:
             # Remove package from the directory.
             package_path.unlink()
-            await unregister.wait_for_fn_call(10)
+            await local_collector.update()
 
             # Package got unregistered in the indexer and local collector.
-            mock_unregister.assert_awaited_with(package.hash, local_collector)
+            mock_unregister.assert_awaited_once_with(package.hash, local_collector)
             with pytest.raises(FileNotFoundError):
                 await local_collector.get_path(package)
 
@@ -173,10 +181,9 @@ async def test_package_gets_moved_from_package_to_package(tmp_path_factory: Temp
     async with local_collector:
         with patch.object(local_collector.indexer, 'register_package') as mock_register, \
              patch.object(local_collector.indexer, 'unregister_package') as mock_unregister:
-
             # Rename the package.
             src_path.rename(dest_path)
-            await sleep(0.5)
+            await local_collector.update()
 
             # Package should neither get registered in nor unregistered from the indexer.
             mock_register.assert_not_awaited()
@@ -195,14 +202,13 @@ async def test_package_gets_moved_from_non_package_to_package(tmp_path_factory: 
     package = Package(PACKAGE.hash, PACKAGE.manifest)
 
     async with local_collector:
-        register = WaitForAsyncFunctionCall(local_collector.indexer.register_package)
-        with patch.object(local_collector.indexer, 'register_package', side_effect=register.wrap) as mock_register:
+        with patch.object(local_collector.indexer, 'register_package') as mock_register:
             # Rename the package.
             src_path.rename(dest_path)
-            await register.wait_for_fn_call(10)
+            await local_collector.update()
 
             # Package got registered in the indexer and local collector.
-            mock_register.assert_awaited_with(package.hash, dest_path, local_collector)
+            mock_register.assert_awaited_once_with(package.hash, dest_path, local_collector)
             assert dest_path == await local_collector.get_path(package)
 
 
@@ -215,15 +221,13 @@ async def test_package_gets_moved_from_package_to_non_package(tmp_path_factory: 
     package = Package(PACKAGE.hash, PACKAGE.manifest)
 
     async with local_collector:
-        unregister = WaitForAsyncFunctionCall(local_collector.indexer.unregister_package)
-        with patch.object(local_collector.indexer, 'unregister_package',
-                          side_effect=unregister.wrap) as mock_unregister:
+        with patch.object(local_collector.indexer, 'unregister_package') as mock_unregister:
             # Rename the package.
             Path(src_path).rename(dest_path)
-            await unregister.wait_for_fn_call(10)
+            await local_collector.update()
 
             # Package got unregistered in the indexer and local collector.
-            mock_unregister.assert_awaited_with(package.hash, local_collector)
+            mock_unregister.assert_awaited_once_with(package.hash, local_collector)
             with pytest.raises(FileNotFoundError):
                 await local_collector.get_path(package)
 
@@ -250,14 +254,37 @@ async def test_package_gets_moved_to_different_folder(tmp_path_factory: TempPath
     package = Package(PACKAGE.hash, PACKAGE.manifest)
 
     async with local_collector:
-        unregister = WaitForAsyncFunctionCall(local_collector.indexer.unregister_package)
-        with patch.object(local_collector.indexer, 'unregister_package',
-                          side_effect=unregister.wrap) as mock_unregister:
+        with patch.object(local_collector.indexer, 'unregister_package') as mock_unregister:
             # Move the package.
             src_path.rename(new_directory / src_path.name)
-            await unregister.wait_for_fn_call(10)
+            await local_collector.update()
 
             # Package got unregistered in the indexer and local collector.
-            mock_unregister.assert_awaited_with(package.hash, local_collector)
+            mock_unregister.assert_awaited_once_with(package.hash, local_collector)
             with pytest.raises(FileNotFoundError):
                 await local_collector.get_path(package)
+
+
+async def test_package_filenames_get_swapped(tmp_path_factory: TempPathFactory) -> None:
+    local_collector, directory = create_local_collector(tmp_path_factory)
+
+    package_1_path = Path(copy(PACKAGE.path, directory))
+    package_1 = Package(PACKAGE.hash, PACKAGE.manifest)
+
+    package_2_path = Path(copy(PACKAGE_2.path, directory))
+    package_2 = Package(PACKAGE_2.hash, PACKAGE_2.manifest)
+
+    async with local_collector:
+        with patch.object(local_collector.indexer, 'register_package') as mock_register, \
+             patch.object(local_collector.indexer, 'unregister_package') as mock_unregister:
+            # Swap the package filenames.
+            package_1_path, package_2_path = package_2_path, package_1_path
+            await local_collector.update()
+
+            # The packages should be swapped in the local collector.
+            assert package_2_path == await local_collector.get_path(package_1)
+            assert package_1_path == await local_collector.get_path(package_2)
+
+            # Packages should neither get registered in nor unregistered from the indexer.
+            mock_register.assert_not_awaited()
+            mock_unregister.assert_not_awaited()


### PR DESCRIPTION
Closes #35.

Statt sofort auf Änderungen im Dateisystem zu reagieren, bietet der `LocalCollector` die Methode `update` an. Mit dem Aufruf dieser Methode, wird ein Snapshot des Ordners erstellt und mit einem vorherigen Snapshot verglichen. Änderungen zwischen den beiden Snapshots werden anschließend in der internen `PathToHash`-Map und dem `Indexer` übernommen.

Beim Aufruf von `start` wird ein Signal-Handler für `SIGUSR1` erstellt, welcher `update` aufruft. Dadurch kann z.B. über `kill -s USR1 $PID` der `LocalCollector` geupdatet werden, nachdem Änderungen im Ordner vorgenommen wurden.
Die Methode `stop`, enternt diesen Handler wieder.