### PR TITLE
refactor: use pydantics builtin `ByteSize` for byte representation

### DIFF
--- a/config.example.ini
+++ b/config.example.ini
@@ -11,26 +11,26 @@
 # The port the http server should bind to
 #listen_port = 9020
 
-# Maximum package size in bytes (at least 20MB)
-#max_bytes_package = 20971520
+# Maximum package size (at least 20 MiB)
+#max_package_size = 20 MiB
 
 [worker]
 # Maximum amount of running workers
 #max_workers = 8
 
 # Maximum combined memory usage of all workers
-#max_memory = 524288000
+#max_memory = 500 MiB
 
 [cache_package]
-# Maximum cache size in bytes
-#size = 104857600
+# Maximum cache size
+#size = 100 MiB
 
 # The path of the cache (relative or absolute)
 #path = cache/packages
 
 [cache_question_state]
-# Maximum cache size in bytes
-#size = 20971520
+# Maximum cache size
+#size = 20 MiB
 
 # The path of the cache (relative or absolute)
 #path = cache/question_states

--- a/poetry.lock
+++ b/poetry.lock
@@ -126,19 +126,19 @@ frozenlist = ">=1.1.0"
 
 [[package]]
 name = "astroid"
-version = "2.13.2"
+version = "2.13.3"
 description = "An abstract syntax tree for Python with inference support."
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "astroid-2.13.2-py3-none-any.whl", hash = "sha256:8f6a8d40c4ad161d6fc419545ae4b2f275ed86d1c989c97825772120842ee0d2"},
-    {file = "astroid-2.13.2.tar.gz", hash = "sha256:3bc7834720e1a24ca797fd785d77efb14f7a28ee8e635ef040b6e2d80ccb3303"},
+    {file = "astroid-2.13.3-py3-none-any.whl", hash = "sha256:14c1603c41cc61aae731cad1884a073c4645e26f126d13ac8346113c95577f3b"},
+    {file = "astroid-2.13.3.tar.gz", hash = "sha256:6afc22718a48a689ca24a97981ad377ba7fb78c133f40335dfd16772f29bcfb1"},
 ]
 
 [package.dependencies]
 lazy-object-proxy = ">=1.4.0"
-typing-extensions = ">=4.0.0"
+typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.11\""}
 wrapt = [
     {version = ">=1.11,<2", markers = "python_version < \"3.11\""},
     {version = ">=1.14,<2", markers = "python_version >= \"3.11\""},
@@ -177,14 +177,14 @@ tests-no-zope = ["cloudpickle", "cloudpickle", "hypothesis", "hypothesis", "mypy
 
 [[package]]
 name = "cachetools"
-version = "5.2.1"
+version = "5.3.0"
 description = "Extensible memoizing collections and decorators"
 category = "dev"
 optional = false
 python-versions = "~=3.7"
 files = [
-    {file = "cachetools-5.2.1-py3-none-any.whl", hash = "sha256:8462eebf3a6c15d25430a8c27c56ac61340b2ecf60c9ce57afc2b97e450e47da"},
-    {file = "cachetools-5.2.1.tar.gz", hash = "sha256:5991bc0e08a1319bb618d3195ca5b6bc76646a49c21d55962977197b301cc1fe"},
+    {file = "cachetools-5.3.0-py3-none-any.whl", hash = "sha256:429e1a1e845c008ea6c85aa35d4b98b65d6a9763eeef3e37e92728a12d1de9d4"},
+    {file = "cachetools-5.3.0.tar.gz", hash = "sha256:13dfddc7b8df938c21a940dfa6557ce6e94a2f1cdfa58eb90c805721d58f2c14"},
 ]
 
 [[package]]
@@ -336,14 +336,14 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "faker"
-version = "16.3.0"
+version = "16.6.1"
 description = "Faker is a Python package that generates fake data for you."
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "Faker-16.3.0-py3-none-any.whl", hash = "sha256:084ad2fbb365ab2c82193e72abf3a6f5c70777b3706e176c37c655b40113d82e"},
-    {file = "Faker-16.3.0.tar.gz", hash = "sha256:79354c15477e7ee41067cd75e033155ec9b669adbf7bbce8b66e54893cfee1e4"},
+    {file = "Faker-16.6.1-py3-none-any.whl", hash = "sha256:2375d0bbaf405dc4f1cbc771485a78ad952c776798e5c228eef3e7b337f78868"},
+    {file = "Faker-16.6.1.tar.gz", hash = "sha256:b76e5d2405470e3d38d37d1bfaa9d9bbf171bdf41c814f5bbd8117b121f6bccb"},
 ]
 
 [package.dependencies]
@@ -492,19 +492,19 @@ files = [
 
 [[package]]
 name = "isort"
-version = "5.11.4"
+version = "5.12.0"
 description = "A Python utility / library to sort Python imports."
 category = "dev"
 optional = false
-python-versions = ">=3.7.0"
+python-versions = ">=3.8.0"
 files = [
-    {file = "isort-5.11.4-py3-none-any.whl", hash = "sha256:c033fd0edb91000a7f09527fe5c75321878f98322a77ddcc81adbd83724afb7b"},
-    {file = "isort-5.11.4.tar.gz", hash = "sha256:6db30c5ded9815d813932c04c2f85a360bcdd35fed496f4d8f35495ef0a261b6"},
+    {file = "isort-5.12.0-py3-none-any.whl", hash = "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"},
+    {file = "isort-5.12.0.tar.gz", hash = "sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504"},
 ]
 
 [package.extras]
-colors = ["colorama (>=0.4.3,<0.5.0)"]
-pipfile-deprecated-finder = ["pipreqs", "requirementslib"]
+colors = ["colorama (>=0.4.3)"]
+pipfile-deprecated-finder = ["pip-shims (>=0.5.2)", "pipreqs", "requirementslib"]
 plugins = ["setuptools"]
 requirements-deprecated-finder = ["pip-api", "pipreqs"]
 
@@ -816,14 +816,14 @@ email = ["email-validator (>=1.0.3)"]
 
 [[package]]
 name = "pydantic-factories"
-version = "1.17.0"
+version = "1.17.1"
 description = "Mock data generation for pydantic based models and python dataclasses"
 category = "main"
 optional = false
 python-versions = ">=3.8,<4.0"
 files = [
-    {file = "pydantic_factories-1.17.0-py3-none-any.whl", hash = "sha256:11c267ccbb7d54b1b456f68060f31472a5e53151314679e6f9367962b4d3a6f8"},
-    {file = "pydantic_factories-1.17.0.tar.gz", hash = "sha256:f6b2cdf715f8c3e4a84e2851c0fb493af2009398159594c000192a38ce192129"},
+    {file = "pydantic_factories-1.17.1-py3-none-any.whl", hash = "sha256:05c0b143540f54d9dd9d0d500b7b146ff29e0c1cd4bb5f2ed99c60842ff1d5e6"},
+    {file = "pydantic_factories-1.17.1.tar.gz", hash = "sha256:85848136cd768894dc5b6e3ffaf49753c7627c545ef05ff096ff616071cd59ff"},
 ]
 
 [package.dependencies]
@@ -875,14 +875,14 @@ testutils = ["gitpython (>3)"]
 
 [[package]]
 name = "pyproject-api"
-version = "1.4.0"
+version = "1.5.0"
 description = "API to interact with the python pyproject.toml based projects"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pyproject_api-1.4.0-py3-none-any.whl", hash = "sha256:c34226297781efdd1ba4dfb74ce21076d9a8360e2125ea31803c1a02c76b2460"},
-    {file = "pyproject_api-1.4.0.tar.gz", hash = "sha256:ac85c1f82e0291dbae5a7739dbb9a990e11ee4034c9b5599ea714f07a24ecd71"},
+    {file = "pyproject_api-1.5.0-py3-none-any.whl", hash = "sha256:4c111277dfb96bcd562c6245428f27250b794bfe3e210b8714c4f893952f2c17"},
+    {file = "pyproject_api-1.5.0.tar.gz", hash = "sha256:0962df21f3e633b8ddb9567c011e6c1b3dcdfc31b7860c0ede7e24c5a1200fbe"},
 ]
 
 [package.dependencies]
@@ -895,14 +895,14 @@ testing = ["covdefaults (>=2.2.2)", "importlib-metadata (>=5.1)", "pytest (>=7.2
 
 [[package]]
 name = "pytest"
-version = "7.2.0"
+version = "7.2.1"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.2.0-py3-none-any.whl", hash = "sha256:892f933d339f068883b6fd5a459f03d85bfcb355e4981e146d2c7616c21fef71"},
-    {file = "pytest-7.2.0.tar.gz", hash = "sha256:c4014eb40e10f11f355ad4e3c2fb2c6c6d1919c73f3b5a433de4708202cade59"},
+    {file = "pytest-7.2.1-py3-none-any.whl", hash = "sha256:c7c6ca206e93355074ae32f7403e8ea12163b1163c976fee7d4d84027c162be5"},
+    {file = "pytest-7.2.1.tar.gz", hash = "sha256:d45e0952f3727241918b8fd0f376f5ff6b301cc0777c6f9a556935c92d8a7d42"},
 ]
 
 [package.dependencies]
@@ -1003,8 +1003,8 @@ pydantic-factories = "^1.6.2"
 [package.source]
 type = "git"
 url = "https://github.com/questionpy-org/questionpy-common.git"
-reference = "07ca576"
-resolved_reference = "07ca576b4497a9c50b3a2d9d9db5cef98af7b652"
+reference = "0abdbbb"
+resolved_reference = "0abdbbb4d2fb278341737cb0ebcc3c1e03547ce6"
 
 [[package]]
 name = "six"
@@ -1044,14 +1044,14 @@ files = [
 
 [[package]]
 name = "tox"
-version = "4.2.8"
+version = "4.4.2"
 description = "tox is a generic virtualenv management and test command line tool"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "tox-4.2.8-py3-none-any.whl", hash = "sha256:e9d5006a533d280e2ca26e3ca61052ffa55a65b683486f92d12563a14a9b7a4f"},
-    {file = "tox-4.2.8.tar.gz", hash = "sha256:7c31940d755355210151e8bef23feab3d714a8a4795e513c454ff0baccd995b1"},
+    {file = "tox-4.4.2-py3-none-any.whl", hash = "sha256:258895ba5de919490c03ef97467c4c8c42954537dfd96ae72cc2fb63dac67cf0"},
+    {file = "tox-4.4.2.tar.gz", hash = "sha256:3d8a8dd8a5afdc0d37af3e2b4959e427fe22530d0aa599baf0120e144b3defa3"},
 ]
 
 [package.dependencies]
@@ -1062,7 +1062,7 @@ filelock = ">=3.9"
 packaging = ">=23"
 platformdirs = ">=2.6.2"
 pluggy = ">=1"
-pyproject-api = ">=1.4"
+pyproject-api = ">=1.5"
 tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
 virtualenv = ">=20.17.1"
 
@@ -1327,4 +1327,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "66304f13404d5d6d4fda5de200a3defb81db4feeb3ad41246cf0266ecab3f0a6"
+content-hash = "712994f22a15eede22d3b49bee427391f253ee26503e39f9fa931dd65f47701c"

--- a/poetry.lock
+++ b/poetry.lock
@@ -126,14 +126,14 @@ frozenlist = ">=1.1.0"
 
 [[package]]
 name = "astroid"
-version = "2.13.3"
+version = "2.14.1"
 description = "An abstract syntax tree for Python with inference support."
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "astroid-2.13.3-py3-none-any.whl", hash = "sha256:14c1603c41cc61aae731cad1884a073c4645e26f126d13ac8346113c95577f3b"},
-    {file = "astroid-2.13.3.tar.gz", hash = "sha256:6afc22718a48a689ca24a97981ad377ba7fb78c133f40335dfd16772f29bcfb1"},
+    {file = "astroid-2.14.1-py3-none-any.whl", hash = "sha256:23c718921acab5f08cbbbe9293967f1f8fec40c336d19cd75dc12a9ea31d2eb2"},
+    {file = "astroid-2.14.1.tar.gz", hash = "sha256:bd1aa4f9915c98e8aaebcd4e71930154d4e8c9aaf05d35ac0a63d1956091ae3f"},
 ]
 
 [package.dependencies]
@@ -695,14 +695,14 @@ reports = ["lxml"]
 
 [[package]]
 name = "mypy-extensions"
-version = "0.4.3"
-description = "Experimental type system extensions for programs checked with the mypy typechecker."
+version = "1.0.0"
+description = "Type system extensions for programs checked with the mypy type checker."
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=3.5"
 files = [
-    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
-    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
+    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
 ]
 
 [[package]]
@@ -845,18 +845,18 @@ files = [
 
 [[package]]
 name = "pylint"
-version = "2.15.10"
+version = "2.16.1"
 description = "python code static checker"
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "pylint-2.15.10-py3-none-any.whl", hash = "sha256:9df0d07e8948a1c3ffa3b6e2d7e6e63d9fb457c5da5b961ed63106594780cc7e"},
-    {file = "pylint-2.15.10.tar.gz", hash = "sha256:b3dc5ef7d33858f297ac0d06cc73862f01e4f2e74025ec3eff347ce0bc60baf5"},
+    {file = "pylint-2.16.1-py3-none-any.whl", hash = "sha256:bad9d7c36037f6043a1e848a43004dfd5ea5ceb05815d713ba56ca4503a9fe37"},
+    {file = "pylint-2.16.1.tar.gz", hash = "sha256:ffe7fa536bb38ba35006a7c8a6d2efbfdd3d95bbf21199cad31f76b1c50aaf30"},
 ]
 
 [package.dependencies]
-astroid = ">=2.12.13,<=2.14.0-dev0"
+astroid = ">=2.14.1,<=2.16.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
     {version = ">=0.2", markers = "python_version < \"3.11\""},
@@ -1003,8 +1003,8 @@ pydantic-factories = "^1.6.2"
 [package.source]
 type = "git"
 url = "https://github.com/questionpy-org/questionpy-common.git"
-reference = "0abdbbb"
-resolved_reference = "0abdbbb4d2fb278341737cb0ebcc3c1e03547ce6"
+reference = "a43ccb2"
+resolved_reference = "a43ccb2a8423f18e063f9ac6b23df85ba8835c72"
 
 [[package]]
 name = "six"
@@ -1044,14 +1044,14 @@ files = [
 
 [[package]]
 name = "tox"
-version = "4.4.2"
+version = "4.4.4"
 description = "tox is a generic virtualenv management and test command line tool"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "tox-4.4.2-py3-none-any.whl", hash = "sha256:258895ba5de919490c03ef97467c4c8c42954537dfd96ae72cc2fb63dac67cf0"},
-    {file = "tox-4.4.2.tar.gz", hash = "sha256:3d8a8dd8a5afdc0d37af3e2b4959e427fe22530d0aa599baf0120e144b3defa3"},
+    {file = "tox-4.4.4-py3-none-any.whl", hash = "sha256:1195820ca35b141ce5ab040c9dfad8f03de6897c9bd867c6151dfb7dc58e64cd"},
+    {file = "tox-4.4.4.tar.gz", hash = "sha256:e1ef01d9e9503b1218511f74517dc3f0008c8b5e0cc53ab7f51ff3c2ca63b349"},
 ]
 
 [package.dependencies]
@@ -1102,14 +1102,14 @@ files = [
 
 [[package]]
 name = "virtualenv"
-version = "20.17.1"
+version = "20.18.0"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "virtualenv-20.17.1-py3-none-any.whl", hash = "sha256:ce3b1684d6e1a20a3e5ed36795a97dfc6af29bc3970ca8dab93e11ac6094b3c4"},
-    {file = "virtualenv-20.17.1.tar.gz", hash = "sha256:f8b927684efc6f1cc206c9db297a570ab9ad0e51c16fa9e45487d36d1905c058"},
+    {file = "virtualenv-20.18.0-py3-none-any.whl", hash = "sha256:9d61e4ec8d2c0345dab329fb825eb05579043766a4b26a2f66b28948de68c722"},
+    {file = "virtualenv-20.18.0.tar.gz", hash = "sha256:f262457a4d7298a6b733b920a196bf8b46c8af15bf1fd9da7142995eff15118e"},
 ]
 
 [package.dependencies]
@@ -1118,8 +1118,8 @@ filelock = ">=3.4.1,<4"
 platformdirs = ">=2.4,<3"
 
 [package.extras]
-docs = ["proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-argparse (>=0.3.2)", "sphinx-rtd-theme (>=1)", "towncrier (>=22.8)"]
-testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=21.3)", "pytest (>=7.0.1)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.2)", "pytest-mock (>=3.6.1)", "pytest-randomly (>=3.10.3)", "pytest-timeout (>=2.1)"]
+docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=6.1.3)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=22.12)"]
+test = ["covdefaults (>=2.2.2)", "coverage (>=7.1)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23)", "pytest (>=7.2.1)", "pytest-env (>=0.8.1)", "pytest-freezegun (>=0.4.2)", "pytest-mock (>=3.10)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)"]
 
 [[package]]
 name = "watchdog"
@@ -1327,4 +1327,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "712994f22a15eede22d3b49bee427391f253ee26503e39f9fa931dd65f47701c"
+content-hash = "a480f81f0f3bddfa028c3065abbfacfd53574f7e77365dae65ee94bfc38afb18"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,8 @@ version = "0.1.1"
 python = "^3.9"
 aiohttp = "^3.8.1"
 pydantic = "^1.9.1"
-questionpy-common = { git = "https://github.com/questionpy-org/questionpy-common.git", rev = "07ca576" }
-watchdog = "^2.2.1"
+watchdog = "^2.2.0"
+questionpy-common = { git = "https://github.com/questionpy-org/questionpy-common.git", rev = "0abdbbb" }
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.14.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ python = "^3.9"
 aiohttp = "^3.8.1"
 pydantic = "^1.9.1"
 watchdog = "^2.2.0"
-questionpy-common = { git = "https://github.com/questionpy-org/questionpy-common.git", rev = "0abdbbb" }
+questionpy-common = { git = "https://github.com/questionpy-org/questionpy-common.git", rev = "a43ccb2" }
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.14.5"

--- a/questionpy_server/app.py
+++ b/questionpy_server/app.py
@@ -14,7 +14,7 @@ from .worker.controller import WorkerPool
 class QPyServer:
     def __init__(self, settings: Settings):
         self.settings: Settings = settings
-        self.web_app = web.Application(client_max_size=settings.webservice.max_bytes_main)
+        self.web_app = web.Application(client_max_size=settings.webservice.max_main_size)
         self.web_app.add_routes(routes)
         self.web_app['qpy_server_app'] = self
         self.worker_pool = WorkerPool(settings.worker.max_workers, settings.worker.max_memory)

--- a/questionpy_server/cache.py
+++ b/questionpy_server/cache.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from typing import NamedTuple, Callable, Awaitable
 from asyncio import to_thread, Lock
 
+from pydantic import ByteSize
+
 
 class File(NamedTuple):
     path: Path
@@ -11,7 +13,7 @@ class File(NamedTuple):
 
 
 class SizeError(Exception):
-    def __init__(self, message: str = '', max_size: float = 0, actual_size: float = 0):
+    def __init__(self, message: str = '', max_size: int = 0, actual_size: int = 0):
         super().__init__(message)
 
         self.max_size = max_size
@@ -24,7 +26,7 @@ class FileLimitLRU:
     Only `bytes` type values are accepted. Their size is calculated by passing them into the builtin `len()` function.
     """
 
-    def __init__(self, directory: Path, max_bytes: int, extension: str = None, name: str = None) -> None:
+    def __init__(self, directory: Path, max_size: int, extension: str = None, name: str = None) -> None:
         """
         A cache should be initialised while starting a server therefore it is not necessary for it to be async.
         """
@@ -37,8 +39,8 @@ class FileLimitLRU:
 
         self.directory: Path = directory
 
-        self.max_bytes = max_bytes
-        self._total_bytes = 0
+        self.max_size = max_size
+        self._total_size: int = 0
 
         self._extension: str = '' if extension is None else '.' + extension.lstrip('.')
         self._tmp_extension: str = '.tmp'
@@ -58,19 +60,19 @@ class FileLimitLRU:
                 continue
 
             size = path.stat().st_size
-            total = self._total_bytes + size
+            total = self._total_size + size
 
             # Remove files if cache is full.
-            if total > self.max_bytes:
+            if total > self.max_size:
                 path.unlink()
                 continue
 
-            self._total_bytes = total
+            self._total_size = total
             self._files[path.stem] = File(path, size)
 
         log = logging.getLogger('questionpy-server')
-        log.info('%s initialised at %s with %d file(s) and %d/%d byte(s)', self._name, self.directory,
-                 len(self._files), self._total_bytes, self.max_bytes)
+        log.info('%s initialised at %s with %d file(s) and %s/%s.', self._name, self.directory, len(self._files),
+                 ByteSize(self._total_size).human_readable(), ByteSize(self.max_size).human_readable())
 
     def contains(self, key: str) -> bool:
         """
@@ -99,7 +101,7 @@ class FileLimitLRU:
     async def _remove(self, key: str) -> None:
         file = self._get_file(key)
         await to_thread(file.path.unlink, missing_ok=True)
-        self._total_bytes -= file.size
+        self._total_size -= file.size
         del self._files[key]
 
         await self.on_remove(key)
@@ -127,11 +129,11 @@ class FileLimitLRU:
             raise TypeError("Not a bytes object:", repr(value))
 
         size = len(value)
-        if size > self.max_bytes:
+        if size > self.max_size:
             # If we allowed this, the loop at the end would remove all items from the dictionary,
             # so we raise an error to allow exceptions for this case.
-            raise SizeError(f"Item itself exceeds maximum allowed size of {self.max_bytes} bytes",
-                            max_size=self.max_bytes, actual_size=size)
+            raise SizeError(f"Item itself exceeds maximum allowed size of {ByteSize(self.max_size).human_readable()}",
+                            max_size=self.max_size, actual_size=size)
 
         async with self._lock:
             # Save the bytes on filesystem.
@@ -145,14 +147,14 @@ class FileLimitLRU:
 
             # Update `_total_bytes` depending on whether the key existed already or not.
             if key in self._files:
-                self._total_bytes -= self._files[key].size
-            self._total_bytes += size
+                self._total_size -= self._files[key].size
+            self._total_size += size
 
             # Update internal file dictionary.
             self._files[key] = File(path, size)
 
             # If size is too large now, remove items until it is less than or equal to the defined maximum.
-            while self._total_bytes > self.max_bytes:
+            while self._total_size > self.max_size:
                 # Delete the current oldest item, by instantiating an iterator over all keys (in order)
                 # and passing its next item (i.e. the first one in order) to self.remove().
                 await self._remove(next(iter(self._files)))
@@ -160,12 +162,12 @@ class FileLimitLRU:
             return path
 
     @property
-    def total_bytes(self) -> int:
-        return self._total_bytes
+    def total_size(self) -> int:
+        return self._total_size
 
     @property
     def space_left(self) -> int:
-        return self.max_bytes - self._total_bytes
+        return self.max_size - self._total_size
 
     @property
     def files(self) -> OrderedDict[str, File]:

--- a/questionpy_server/misc.py
+++ b/questionpy_server/misc.py
@@ -3,6 +3,8 @@ from inspect import Parameter, signature, isclass
 from pathlib import Path
 from typing import Callable, List, Type, Tuple
 
+from questionpy_common.constants import MiB
+
 from questionpy_server.types import RouteHandler, M
 
 
@@ -26,7 +28,7 @@ def get_route_model_param(route_handler: RouteHandler, model: Type[M]) -> Tuple[
     return params[0].name, params[0].annotation
 
 
-def calculate_hash(path: Path, chunk_size: int = 5_242_880) -> str:
+def calculate_hash(path: Path, chunk_size: int = 5 * MiB) -> str:
     """Calculate SHA256 hash of a file."""
     package_hash = sha256()
 

--- a/questionpy_server/worker/controller.py
+++ b/questionpy_server/worker/controller.py
@@ -3,9 +3,10 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Optional
+
+from questionpy_common.constants import MiB
 from questionpy_common.manifest import Manifest
 from questionpy_common.elements import OptionsFormDefinition
-from questionpy_common.misc import Size, SizeUnit
 
 from .exception import WorkerStartError
 from .worker import WorkerProcessBase, WorkerProcess, WorkerResourceLimits
@@ -74,7 +75,7 @@ class WorkerPool:
             if context is None:
                 context = 0
             try:
-                limits = WorkerResourceLimits(max_memory=Size(200, SizeUnit.MiB),
+                limits = WorkerResourceLimits(max_memory=200 * MiB,
                                               max_cpu_time_seconds_per_call=10)  # TODO
                 if self.max_memory < limits.max_memory:
                     raise WorkerStartError("The worker needs more memory than available.")

--- a/questionpy_server/worker/runtime/lib.py
+++ b/questionpy_server/worker/runtime/lib.py
@@ -6,8 +6,6 @@ from io import BufferedReader, RawIOBase
 from pathlib import Path
 from typing import Any, Optional, Union, Callable, TypeVar, TYPE_CHECKING
 
-from questionpy_common.misc import Size
-
 from .messages import InitWorker, Exit, get_message_bytes, messages_header_struct, Message, MessageIds, \
     MessageToWorker, MessageToServer, InvalidMessageIdError, GetQPyPackageManifest, LoadQPyPackage, \
     GetOptionsFormDefinition, WorkerError
@@ -20,7 +18,7 @@ if TYPE_CHECKING:
 @dataclass
 class WorkerResourceLimits:
     """Maximum resources that a worker process is allowed to consume."""
-    max_memory: Size
+    max_memory: int
     max_cpu_time_seconds_per_call: float
 
 
@@ -95,7 +93,7 @@ class WorkerManager:
         if not isinstance(init_msg, InitWorker):
             raise BootstrapError()
 
-        self.limits = WorkerResourceLimits(max_memory=Size(init_msg.max_memory),
+        self.limits = WorkerResourceLimits(max_memory=init_msg.max_memory,
                                            max_cpu_time_seconds_per_call=init_msg.max_cpu_time)
         # Limit memory usage.
         resource.setrlimit(resource.RLIMIT_AS, (self.limits.max_memory, self.limits.max_memory))

--- a/questionpy_server/worker/worker.py
+++ b/questionpy_server/worker/worker.py
@@ -9,7 +9,9 @@ from enum import Enum
 from pathlib import Path
 from typing import Optional, Type, TypeVar
 
-from questionpy_common.misc import Size, SizeUnit
+from pydantic import ByteSize
+
+from questionpy_common.constants import KiB
 
 from .exception import WorkerNotRunningError, WorkerStartError
 from .runtime.lib import WorkerResourceLimits, send_message
@@ -20,7 +22,7 @@ from .runtime.messages import MessageIds, messages_header_struct, MessageToServe
 @dataclass
 class WorkerResources:
     """Current resource usage."""
-    memory_bytes: Size
+    memory: int
     cpu_time_since_last_call: float
     total_cpu_time: float
 
@@ -85,7 +87,7 @@ class WorkerProcess(WorkerProcessBase):
         self._expected_incoming_messages: list[tuple[MessageIds, asyncio.Future]] = []
 
         self.stderr_data: bytearray = bytearray()
-        self._stderr_data_max_size: Size = Size(5, SizeUnit.KiB)
+        self._stderr_data_max_size: int = 5 * KiB
         self.stderr_skipped_data: int = 0
         self.ignore_errors: bool = False  # do not log errors in worker when reading from stdin
 
@@ -121,7 +123,7 @@ class WorkerProcess(WorkerProcessBase):
 
     def get_resource_usage(self) -> WorkerResources:
         return WorkerResources(
-            memory_bytes=Size(self.limits.max_memory),
+            memory=self.limits.max_memory,
             cpu_time_since_last_call=0,
             total_cpu_time=0,
         )
@@ -183,7 +185,7 @@ class WorkerProcess(WorkerProcessBase):
 
         # Skip all the remaining data in stderr.
         while True:
-            data = await self.proc.stderr.read(Size(512, SizeUnit.KiB))
+            data = await self.proc.stderr.read(512 * KiB)
             if not data:
                 return
             self.stderr_skipped_data += len(data)
@@ -194,7 +196,7 @@ class WorkerProcess(WorkerProcessBase):
             msg = "Worker wrote following data to stdout/stderr.\n"
             msg_after = ""
             if self.stderr_skipped_data:
-                msg_after += f" (additional {Size(self.stderr_skipped_data)} were skipped)."
+                msg_after += f" (additional {ByteSize(self.stderr_skipped_data).human_readable()} were skipped)."
             log.warning("%s%s%s ", msg, self.stderr_data.decode('utf-8', errors='replace'), msg_after)
         self.stderr_data = bytearray()
         self.stderr_skipped_data = 0

--- a/tests/collector/test_indexer.py
+++ b/tests/collector/test_indexer.py
@@ -4,6 +4,8 @@ from typing import Union
 from unittest.mock import patch
 
 import pytest
+
+from questionpy_common.constants import MiB
 from questionpy_common.manifest import Manifest
 
 from questionpy_server import WorkerPool
@@ -19,7 +21,7 @@ from tests.conftest import PACKAGE
 @pytest.mark.parametrize('kind', [PACKAGE.path, PACKAGE.manifest])
 @patch('questionpy_server.collector.lms_collector.LMSCollector', spec=LMSCollector)
 async def test_register_package_with_path_and_manifest(collector: LMSCollector, kind: Union[Path, Manifest]) -> None:
-    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
+    indexer = Indexer(WorkerPool(1, 200 * MiB))
     await indexer.register_package(PACKAGE.hash, kind, collector)
 
     # Package is accessible by hash.
@@ -31,7 +33,7 @@ async def test_register_package_with_path_and_manifest(collector: LMSCollector, 
 
 @patch('questionpy_server.collector.lms_collector.LMSCollector', spec=LMSCollector)
 async def test_register_package_from_lms(collector: LMSCollector) -> None:
-    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
+    indexer = Indexer(WorkerPool(1, 200 * MiB))
     await indexer.register_package(PACKAGE.hash, PACKAGE.manifest, collector)
 
     # Package is not accessible by name and version.
@@ -52,7 +54,7 @@ async def test_register_package_from_local_and_repo_collector(collector: BaseCol
     # Create mock.
     collector = patch(collector.__module__, spec=collector).start()
 
-    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
+    indexer = Indexer(WorkerPool(1, 200 * MiB))
     await indexer.register_package(PACKAGE.hash, PACKAGE.manifest, collector)
 
     # Package is accessible by hash.
@@ -78,7 +80,7 @@ async def test_register_package_from_local_and_repo_collector(collector: BaseCol
 
 
 async def test_register_package_with_same_hash_as_existing_package() -> None:
-    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
+    indexer = Indexer(WorkerPool(1, 200 * MiB))
 
     # Register package from local collector.
     local_collector = patch(LocalCollector.__module__, spec=LocalCollector).start()
@@ -113,7 +115,7 @@ async def test_register_two_packages_with_same_manifest_but_different_hashes(cap
     collector = patch(LocalCollector.__module__, spec=LocalCollector).start()
 
     # Register a package.
-    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
+    indexer = Indexer(WorkerPool(1, 200 * MiB))
     await indexer.register_package(PACKAGE.hash, PACKAGE.manifest, collector)
 
     with caplog.at_level(logging.WARNING):
@@ -126,7 +128,7 @@ async def test_register_two_packages_with_same_manifest_but_different_hashes(cap
 
 
 async def test_unregister_package_with_lms_source() -> None:
-    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
+    indexer = Indexer(WorkerPool(1, 200 * MiB))
     collector = patch(LMSCollector.__module__, spec=LMSCollector).start()
     await indexer.register_package(PACKAGE.hash, PACKAGE.manifest, collector)
 
@@ -139,7 +141,7 @@ async def test_unregister_package_with_lms_source() -> None:
 
 @pytest.mark.parametrize('collector', [LocalCollector, RepoCollector])
 async def test_unregister_package_with_local_and_repo_source(collector: BaseCollector) -> None:
-    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
+    indexer = Indexer(WorkerPool(1, 200 * MiB))
     collector = patch(collector.__module__, spec=collector).start()
     await indexer.register_package(PACKAGE.hash, PACKAGE.manifest, collector)
 
@@ -159,7 +161,7 @@ async def test_unregister_package_with_local_and_repo_source(collector: BaseColl
 
 
 async def test_unregister_package_with_multiple_sources() -> None:
-    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
+    indexer = Indexer(WorkerPool(1, 200 * MiB))
 
     # Register package from local, repo, and LMS collector.
     lms_collector = patch(LMSCollector.__module__, spec=LMSCollector).start()

--- a/tests/collector/test_lms_collector.py
+++ b/tests/collector/test_lms_collector.py
@@ -3,6 +3,8 @@ from unittest.mock import patch
 import pytest
 from _pytest.tmpdir import TempPathFactory
 
+from questionpy_common.constants import KiB, MiB
+
 from questionpy_server import WorkerPool
 from questionpy_server.cache import FileLimitLRU
 from questionpy_server.collector.indexer import Indexer
@@ -21,13 +23,13 @@ def create_lms_collector(tmp_path_factory: TempPathFactory) -> tuple[LMSCollecto
     """
 
     path = tmp_path_factory.mktemp('qpy')
-    cache = FileLimitLRU(path, 20 * 1024 * 1024, extension='.qpy')
-    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
+    cache = FileLimitLRU(path, 20 * KiB, extension='.qpy')
+    indexer = Indexer(WorkerPool(1, 200 * MiB))
     return LMSCollector(cache, indexer), cache
 
 
 async def test_package_in_cache_before_init(tmp_path_factory: TempPathFactory) -> None:
-    cache = FileLimitLRU(tmp_path_factory.mktemp('qpy'), 20 * 1024 * 1024, extension='.qpy')
+    cache = FileLimitLRU(tmp_path_factory.mktemp('qpy'), 20 * KiB, extension='.qpy')
 
     # Put package into cache.
     await cache.put(PACKAGE.hash, PACKAGE.path.read_bytes())

--- a/tests/collector/test_local_collector.py
+++ b/tests/collector/test_local_collector.py
@@ -10,6 +10,8 @@ import asyncio
 import pytest
 from _pytest.tmpdir import TempPathFactory
 
+from questionpy_common.constants import MiB
+
 from questionpy_server.package import Package
 from questionpy_server.worker.controller import WorkerPool
 from questionpy_server.collector.indexer import Indexer
@@ -26,7 +28,7 @@ def create_local_collector(tmp_path_factory: TempPathFactory) -> tuple[LocalColl
     """
 
     path = tmp_path_factory.mktemp('qpy')
-    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
+    indexer = Indexer(WorkerPool(1, 200 * MiB))
     return LocalCollector(path, indexer), path
 
 
@@ -81,7 +83,7 @@ async def test_ignore_files_with_wrong_extension(tmp_path_factory: TempPathFacto
     ignore_file = directory / 'wrong.extension'
     ignore_file.touch()
 
-    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
+    indexer = Indexer(WorkerPool(1, 200 * MiB))
     local_collector = LocalCollector(directory, indexer)
 
     async with local_collector:
@@ -97,7 +99,7 @@ async def test_ignore_files_with_wrong_extension(tmp_path_factory: TempPathFacto
 
 async def test_package_exists_before_init(tmp_path_factory: TempPathFactory) -> None:
     path = tmp_path_factory.mktemp('qpy')
-    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
+    indexer = Indexer(WorkerPool(1, 200 * MiB))
     local_collector = LocalCollector(path, indexer)
 
     package_path = copy(PACKAGE.path, path)
@@ -245,7 +247,7 @@ async def test_package_gets_moved_to_different_folder(tmp_path_factory: TempPath
         # Use new_directory as the directory to be watched and directory to be the new directory of the package.
         directory, new_directory = new_directory, directory
 
-    indexer = Indexer(WorkerPool(1, 200 * 1024 * 1024))
+    indexer = Indexer(WorkerPool(1, 200 * MiB))
     local_collector = LocalCollector(directory, indexer)
 
     # Create a package in the directory.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from _pytest.tmpdir import TempPathFactory
 from aiohttp.pytest_plugin import AiohttpClient
 from aiohttp.test_utils import TestClient
 
+from questionpy_common.constants import KiB
 from questionpy_common.manifest import Manifest
 
 from questionpy_server.app import QPyServer
@@ -22,7 +23,7 @@ from questionpy_server.settings import Settings, WebserviceSettings, PackageCach
 def get_file_hash(path: Path) -> str:
     hash_value = sha256()
     with path.open('rb') as file:
-        while chunk := file.read(4096):
+        while chunk := file.read(4 * KiB):
             hash_value.update(chunk)
     return hash_value.hexdigest()
 
@@ -54,7 +55,7 @@ def qpy_server(tmp_path_factory: TempPathFactory) -> QPyServer:
     server = QPyServer(Settings(
         config_files=(),
         webservice=WebserviceSettings(listen_address="127.0.0.1", listen_port=0),
-        worker=WorkerSettings(max_workers=8, max_memory=524_288_000),
+        worker=WorkerSettings(),
         cache_package=PackageCacheSettings(directory=package_cache_directory),
         cache_question_state=QuestionStateCacheSettings(directory=question_state_cache_directory),
         collector=CollectorSettings()


### PR DESCRIPTION
Beim Einlesen von Bytes in der config.ini wird nun `pydantic.ByteSize()` ([Dokumentation](https://docs.pydantic.dev/usage/types/#bytesize)) verwendet.

Damit kann #34 geschlossen werden.