### PR TITLE
feat: configurable log and overwritable config

### DIFF
--- a/config.example.ini
+++ b/config.example.ini
@@ -4,6 +4,14 @@
 
 # This file shows all available settings with their corresponding default values commented out.
 
+# Every setting can be overwritten by a corresponding environment variable. The environment variable has to
+# follow the pattern "QPY_<SECTION>__<SETTING>" - section and setting are uppercased and separated by two underscores.
+# E.g. the setting general->log_level can be overwritten by the environment variable QPY_GENERAL__LOG_LEVEL.
+
+[general]
+# The log level [NONE, DEBUG, INFO, WARNING, ERROR, CRITICAL]
+#log_level = INFO
+
 [webservice]
 # The address the http server should bind to
 #listen_address = 127.0.0.1

--- a/questionpy_server/__main__.py
+++ b/questionpy_server/__main__.py
@@ -17,13 +17,12 @@ def update_logging(level: str) -> None:
     if level == 'NONE':
         logging.disable()
     elif level in ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']:
-        # We need to set force=True because we might have already set the logging level by logging a message.
-        # reference: https://docs.python.org/3/library/logging.html#logging.basicConfig
-        logging.basicConfig(level=level, force=True)
+        logging.getLogger().setLevel(level)
 
 
 def main() -> None:
     # Initialize logging here because we also log things while reading the settings
+    logging.basicConfig()
     if log_level := os.getenv('QPY_GENERAL__LOG_LEVEL', 'INFO'):
         update_logging(log_level)
 

--- a/questionpy_server/__main__.py
+++ b/questionpy_server/__main__.py
@@ -13,9 +13,19 @@ _DEFAULT_CONFIG_FILES = (
 )
 
 
+def update_logging(level: str) -> None:
+    if level == 'NONE':
+        logging.disable()
+    elif level in ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']:
+        # We need to set force=True because we might have already set the logging level by logging a message.
+        # reference: https://docs.python.org/3/library/logging.html#logging.basicConfig
+        logging.basicConfig(level=level, force=True)
+
+
 def main() -> None:
     # Initialize logging here because we also log things while reading the settings
-    logging.basicConfig(level=os.getenv("QPY_LOGLEVEL", "INFO"))
+    if log_level := os.getenv('QPY_GENERAL__LOG_LEVEL', 'INFO'):
+        update_logging(log_level)
 
     # Arguments
     parser = argparse.ArgumentParser(description=f"QuestionPy Application Server {__version__}")
@@ -23,6 +33,7 @@ def main() -> None:
     args = parser.parse_args()
 
     settings = Settings(config_files=args.config)
+    update_logging(settings.general.log_level)
 
     qpy_server = QPyServer(settings)
     qpy_server.start_server()

--- a/questionpy_server/settings.py
+++ b/questionpy_server/settings.py
@@ -15,7 +15,7 @@ from questionpy_server.worker.worker.subprocess import SubprocessWorker
 
 REPOSITORY_MINIMUM_INTERVAL: Final[timedelta] = timedelta(minutes=5)
 
-_LOG = logging.getLogger('questionpy-server:settings')
+_log = logging.getLogger('questionpy-server:settings')
 
 
 class IniFileSettingsSource:
@@ -25,15 +25,15 @@ class IniFileSettingsSource:
     def __call__(self, settings: BaseSettings) -> dict[str, Any]:
         for path in self._config_files:
             if not path.is_file():
-                _LOG.info("No file found at '%s'", path)
+                _log.info("No file found at '%s'", path)
                 continue
-            _LOG.info("Reading config file '%s'", path)
+            _log.info("Reading config file '%s'", path)
 
             parser = ConfigParser()
             parser.read(path)
             return {key: dict(section) for key, section in parser.items() if key != 'DEFAULT'}
 
-        _LOG.warning('No config file found!')
+        _log.warning('No config file found!')
         return {}
 
 
@@ -192,9 +192,9 @@ class EnvSettingsSourceWrapper:
     def __call__(self, settings: BaseSettings) -> dict[str, Any]:
         env_settings = self._env_settings_source(settings)
         if env_settings:
-            _LOG.info("Reading settings from environment variables, %s in total. Environment variables overwrite "
+            _log.info("Reading settings from environment variables, %s in total. Environment variables overwrite "
                       "settings from the config file.", len(env_settings))
-            _LOG.debug("Following settings were read from environment variables: %s", self._get_settings(env_settings))
+            _log.debug("Following settings were read from environment variables: %s", self._get_settings(env_settings))
         return env_settings
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,8 +15,8 @@ from aiohttp.test_utils import TestClient
 from questionpy_common.constants import KiB
 
 from questionpy_server.app import QPyServer
-from questionpy_server.settings import Settings, WebserviceSettings, PackageCacheSettings, CollectorSettings, \
-    QuestionStateCacheSettings, WorkerSettings, RepoIndexCacheSettings
+from questionpy_server.settings import Settings, GeneralSettings, WebserviceSettings, PackageCacheSettings, \
+    CollectorSettings, QuestionStateCacheSettings, WorkerSettings, RepoIndexCacheSettings
 from questionpy_server.utils.manfiest import ComparableManifest
 
 
@@ -51,6 +51,7 @@ PACKAGE_2 = TestPackage(package_dir / 'package_2.qpy')
 def qpy_server(tmp_path_factory: TempPathFactory) -> QPyServer:
     server = QPyServer(Settings(
         config_files=(),
+        general=GeneralSettings(),
         webservice=WebserviceSettings(listen_address="127.0.0.1", listen_port=0),
         worker=WorkerSettings(),
         cache_package=PackageCacheSettings(directory=tmp_path_factory.mktemp('qpy_package_cache')),

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,85 @@
+import logging
+from configparser import ConfigParser
+from datetime import timedelta
+from os import environ
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+from pydantic.error_wrappers import ValidationError
+from pydantic.networks import HttpUrl
+
+from questionpy_server.settings import EnvSettingsSourceWrapper, Settings
+
+
+@pytest.fixture()
+def path_with_empty_config_file(tmp_path: Path) -> Path:
+    parser = ConfigParser()
+    parser.read_string("""
+        [general]
+        [webservice]
+        [worker]
+        [cache_package]
+        [cache_question_state]
+        [cache_repo_index]
+        [collector]
+    """)
+    path = tmp_path / 'config.ini'
+    with path.open('w') as file:
+        parser.write(file)
+    return path
+
+
+def test_env_settings_source_wrapper(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.DEBUG)
+
+    env_settings_source = Mock(return_value={'test': 'value', 'nested': {'test': 'value'}})
+    settings_wrapper = EnvSettingsSourceWrapper(env_settings_source)
+
+    # Test that the wrapper calls the underlying source.
+    settings = Mock()
+    settings_wrapper(settings)
+    env_settings_source.assert_called_once_with(settings)
+
+    # Test logs.
+    assert caplog.record_tuples[0] == ('questionpy-server:settings', logging.INFO,
+                                       'Reading settings from environment variables, 2 in total. Environment variables '
+                                       'overwrite settings from the config file.')
+
+    logger_name, level, message = caplog.record_tuples[1]
+    assert logger_name == 'questionpy-server:settings' and level == logging.DEBUG
+    assert message.startswith('Following settings were read from environment variables: ')
+    assert message.endswith("{'test: value', 'nested->test: value'}") or \
+           message.endswith("{'nested->test: value', 'test: value'}")
+
+
+def test_env_var_has_higher_priority_than_config_file(path_with_empty_config_file: Path) -> None:
+    config = ConfigParser()
+    config.read(path_with_empty_config_file)
+
+    # Set log level to 'DEBUG' inside config.ini.
+    with path_with_empty_config_file.open('w') as fp:
+        config.set('general', 'log_level', 'DEBUG')
+        config.write(fp)
+
+    # Set log level environment variable to 'WARNING'.
+    with patch.dict(environ, {'QPY_GENERAL__LOG_LEVEL': 'WARNING'}):
+        settings = Settings(config_files=(path_with_empty_config_file,))
+
+        assert settings.general.log_level == 'WARNING'
+
+
+def test_env_var_get_validated(path_with_empty_config_file: Path) -> None:
+    with patch.dict(environ, {'QPY_WEBSERVICE__LISTEN_PORT': 'invalid'}):
+        with pytest.raises(ValidationError, match='webservice -> listen_port\n  value is not a valid integer'):
+            Settings(config_files=(path_with_empty_config_file,))
+
+
+def test_multiline_env_var_gets_parsed_correctly(path_with_empty_config_file: Path) -> None:
+    with patch.dict(environ, {'QPY_COLLECTOR__REPOSITORIES': 'http://www.example.com/1\t3:30:30\n'
+                                                             'http://www.example.com/2 2 7:00:00'}):
+        settings = Settings(config_files=(path_with_empty_config_file, ))
+        assert settings.collector.repositories == {
+            HttpUrl('http://www.example.com/1/', scheme='http'): timedelta(hours=3, minutes=30, seconds=30),
+            HttpUrl('http://www.example.com/2/', scheme='http'): timedelta(days=2, hours=7)
+        }


### PR DESCRIPTION
Das Log-Level kann nun über die Einstellungen geändert werden - zusätzlich zu den normalen Levels (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`), gibt es auch die Möglichkeit `NONE` anzugeben, welches das Loggen deaktiviert.

Zusätzlich können nun auch alle Einstellungen über Umgebungsvariablen gesetzt werden. Diese haben die höchste Priorität und überschreiben ggf. existierende Einstellungen aus Konfigdateien.
Falls Umgebungsvariablen existieren, wird der Nutzer über die Logs informiert.