### PR TITLE
feat: cache repo package index

### DIFF
--- a/config.example.ini
+++ b/config.example.ini
@@ -38,6 +38,13 @@
 # The path of the cache (relative or absolute)
 #path = cache/question_states
 
+[cache_repo_index]
+# Maximum cache size
+#size = 200 MiB
+
+# The path of the cache (relative or absolute)
+#path = cache/repo_index
+
 [collector]
 # Local directory where to look for packages
 #local_directory =

--- a/questionpy_server/app.py
+++ b/questionpy_server/app.py
@@ -25,7 +25,7 @@ class QPyServer:
                                           extension='.qpy', name='PackageCache')
         self.question_state_cache = FileLimitLRU(settings.cache_question_state.directory,
                                                  settings.cache_question_state.size, name='QuestionStateCache')
-        self.repo_index_cache = FileLimitLRU(settings.cache_repo_index.directory, settings.cache_question_state.size,
+        self.repo_index_cache = FileLimitLRU(settings.cache_repo_index.directory, settings.cache_repo_index.size,
                                              name='RepoIndexCache')
 
         self.package_collection = PackageCollection(settings.collector.local_directory, settings.collector.repositories,

--- a/questionpy_server/app.py
+++ b/questionpy_server/app.py
@@ -23,10 +23,13 @@ class QPyServer:
 
         self.package_cache = FileLimitLRU(settings.cache_package.directory, settings.cache_package.size,
                                           extension='.qpy', name='PackageCache')
-        self.package_collection = PackageCollection(settings.collector.local_directory, settings.collector.repositories,
-                                                    self.package_cache, self.worker_pool)
         self.question_state_cache = FileLimitLRU(settings.cache_question_state.directory,
                                                  settings.cache_question_state.size, name='QuestionStateCache')
+        self.repo_index_cache = FileLimitLRU(settings.cache_repo_index.directory, settings.cache_question_state.size,
+                                             name='RepoIndexCache')
+
+        self.package_collection = PackageCollection(settings.collector.local_directory, settings.collector.repositories,
+                                                    self.repo_index_cache, self.package_cache, self.worker_pool)
 
         self.web_app.on_startup.append(self._start_package_collection)
         self.web_app.on_shutdown.append(self._stop_package_collection)

--- a/questionpy_server/cache.py
+++ b/questionpy_server/cache.py
@@ -30,6 +30,11 @@ class FileLimitLRU:
                  name: Optional[str] = None) -> None:
         """A cache should be initialised while starting a server therefore it is not necessary for it to be async."""
 
+        self._extension: str = '' if extension is None else '.' + extension.lstrip('.')
+        self._tmp_extension: str = '.tmp'
+        if self._extension == self._tmp_extension:
+            raise ValueError(f'Extension cannot be "{self._tmp_extension}" as it is used internally.')
+
         async def on_remove(_key: str) -> None:
             pass
 
@@ -41,10 +46,7 @@ class FileLimitLRU:
         self.max_size = max_size
         self._total_size: int = 0
 
-        self._extension: str = '' if extension is None else '.' + extension.lstrip('.')
-        self._tmp_extension: str = '.tmp'
-
-        self._name = name or "Cache"
+        self._name = name or 'Cache'
 
         self._files: OrderedDict[str, File] = OrderedDict()
 
@@ -92,7 +94,11 @@ class FileLimitLRU:
         return self._files[key]
 
     def get(self, key: str) -> Path:
-        """Returns path of the file in the cache."""
+        """Returns path of the file in the cache.
+
+        Raises:
+            FileNotFoundError: If the file does not exist in the cache.
+        """
 
         return self._get_file(key).path
 

--- a/questionpy_server/collector/repo_collector.py
+++ b/questionpy_server/collector/repo_collector.py
@@ -2,23 +2,17 @@ import logging
 from asyncio import sleep, Task, create_task
 from datetime import timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, MutableMapping, Any
+from typing import TYPE_CHECKING, Optional
 
 from questionpy_server.cache import FileLimitLRU
 from questionpy_server.collector.abc import CachedCollector
 from questionpy_server.repository import Repository, RepoMeta, RepoPackage
 from questionpy_server.repository.helper import DownloadError
+from questionpy_server.utils.logger import URLAdapter
 
 if TYPE_CHECKING:
     from questionpy_server.collector.indexer import Indexer
     from questionpy_server.package import Package
-
-
-class URLAdapter(logging.LoggerAdapter):
-    def process(self, msg: str, kwargs: MutableMapping[str, Any]) -> tuple[str, MutableMapping[str, Any]]:
-        if self.extra and 'url' in self.extra:
-            return f'({self.extra["url"]}): {msg}', kwargs
-        return msg, kwargs
 
 
 class RepoCollector(CachedCollector):

--- a/questionpy_server/collector/repo_collector.py
+++ b/questionpy_server/collector/repo_collector.py
@@ -27,10 +27,12 @@ class RepoCollector(CachedCollector):
     This collector is responsible for downloading packages from a remote repository and caching them locally.
     """
 
-    def __init__(self, cache: FileLimitLRU, url: str, update_interval: timedelta, indexer: 'Indexer'):
-        super().__init__(cache=cache, indexer=indexer)
+    def __init__(self, url: str, update_interval: timedelta, package_cache: FileLimitLRU,
+                 repo_index_cache: FileLimitLRU, indexer: 'Indexer'):
+        super().__init__(cache=package_cache, indexer=indexer)
+
         self._url = url
-        self._repository = Repository(self._url)
+        self._repository = Repository(self._url, repo_index_cache)
 
         self._meta: Optional[RepoMeta] = None
         self._index: dict[str, RepoPackage] = {}
@@ -78,7 +80,6 @@ class RepoCollector(CachedCollector):
 
         # Get every package.
         new_packages = await self._repository.get_packages(self._meta)
-        # TODO: cache package index
 
         old_package_hashes = self._index.keys()
         new_package_hashes = new_packages.keys()

--- a/questionpy_server/repository/__init__.py
+++ b/questionpy_server/repository/__init__.py
@@ -1,17 +1,21 @@
+from asyncio import to_thread
 from gzip import decompress
 from urllib.parse import urljoin
 
 from pydantic import parse_raw_as
 
+from questionpy_server.cache import FileLimitLRU
 from questionpy_server.repository.helper import download
 from questionpy_server.repository.models import RepoMeta, RepoPackage, RepoPackageIndex
 
 
 class Repository:
-    def __init__(self, url: str):
+    def __init__(self, url: str, cache: FileLimitLRU):
         self._url_base = url
         self._url_index = urljoin(self._url_base, 'PACKAGES.json.gz')
         self._url_meta = urljoin(self._url_base, 'META.json')
+
+        self._cache = cache
 
     async def get_meta(self) -> RepoMeta:
         """
@@ -30,10 +34,19 @@ class Repository:
         :param meta: metadata
         :return: package index, where keys are package hashes
         """
-        # Download and parse RepoPackageVersions.
-        index_zip = await download(self._url_index, size=meta.size, expected_hash=meta.sha256)
-        index_bytes = decompress(index_zip)
-        index = parse_raw_as(RepoPackageIndex, index_bytes)
+        try:
+            # Try to get the index from cache.
+            raw_index_zip_path = self._cache.get(meta.sha256)
+            raw_index_zip = await to_thread(raw_index_zip_path.read_bytes)
+        except FileNotFoundError:
+            # Download and parse RepoPackageVersions.
+            raw_index_zip = await download(self._url_index, size=meta.size, expected_hash=meta.sha256)
+            if meta.size <= self._cache.max_size:
+                # TODO: What happens if the cache is too small?
+                await self._cache.put(meta.sha256, raw_index_zip)
+
+        raw_index = decompress(raw_index_zip)
+        index = RepoPackageIndex.parse_raw(raw_index)
 
         # Combine general manifest of a package with correct (api-)version.
         packages_dict: dict[str, RepoPackage] = {}

--- a/questionpy_server/settings.py
+++ b/questionpy_server/settings.py
@@ -87,6 +87,16 @@ class QuestionStateCacheSettings(BaseModel):
         return value.resolve()
 
 
+class RepoIndexCacheSettings(BaseModel):
+    size: ByteSize = ByteSize(200 * MiB)
+    directory: DirectoryPath = Path('cache/repo_index').resolve()
+
+    @validator('directory')
+    # pylint: disable=no-self-argument
+    def resolve_path(cls, value: Path) -> Path:
+        return value.resolve()
+
+
 class CollectorSettings(BaseModel):
     local_directory: Optional[DirectoryPath]
     repository_default_interval: timedelta = timedelta(hours=1, minutes=30)
@@ -152,6 +162,7 @@ class Settings(BaseSettings):
     worker: WorkerSettings
     cache_package: PackageCacheSettings
     cache_question_state: QuestionStateCacheSettings
+    cache_repo_index: RepoIndexCacheSettings
     collector: CollectorSettings
 
     config_files: Tuple[Path, ...] = ()

--- a/questionpy_server/utils/logger.py
+++ b/questionpy_server/utils/logger.py
@@ -1,0 +1,9 @@
+import logging
+from typing import MutableMapping, Any
+
+
+class URLAdapter(logging.LoggerAdapter):
+    def process(self, msg: str, kwargs: MutableMapping[str, Any]) -> tuple[str, MutableMapping[str, Any]]:
+        if self.extra and 'url' in self.extra:
+            return f'({self.extra["url"]}): {msg}', kwargs
+        return msg, kwargs

--- a/tests/collector/test_package_collection.py
+++ b/tests/collector/test_package_collection.py
@@ -15,7 +15,7 @@ from questionpy_server.collector.lms_collector import LMSCollector
 
 
 async def test_start() -> None:
-    package_collection = PackageCollection(Path("test_dir/"), {}, Mock(), Mock())
+    package_collection = PackageCollection(Path("test_dir/"), {}, Mock(), Mock(), Mock())
 
     with patch.object(LMSCollector, 'start') as lms_start, patch.object(LocalCollector, 'start') as local_start:
         await package_collection.start()
@@ -24,7 +24,7 @@ async def test_start() -> None:
 
 
 async def test_stop() -> None:
-    package_collection = PackageCollection(Path("test_dir/"), {}, Mock(), Mock())
+    package_collection = PackageCollection(Path("test_dir/"), {}, Mock(), Mock(), Mock())
 
     with patch.object(LMSCollector, 'stop') as lms_stop, patch.object(LocalCollector, 'stop') as local_stop:
         await package_collection.stop()
@@ -33,7 +33,7 @@ async def test_stop() -> None:
 
 
 async def test_put_package() -> None:
-    package_collection = PackageCollection(None, {}, Mock(), Mock())
+    package_collection = PackageCollection(None, {}, Mock(), Mock(), Mock())
 
     with patch.object(LMSCollector, 'put') as put:
         await package_collection.put(HashContainer(b'', 'hash'))
@@ -41,7 +41,7 @@ async def test_put_package() -> None:
 
 
 def test_get_package() -> None:
-    package_collection = PackageCollection(None, {}, Mock(), Mock())
+    package_collection = PackageCollection(None, {}, Mock(), Mock(), Mock())
 
     # Package does exist.
     with patch.object(Indexer, 'get_by_hash') as get_by_hash:
@@ -56,7 +56,7 @@ def test_get_package() -> None:
 
 
 def test_get_package_by_identifier() -> None:
-    package_collection = PackageCollection(None, {}, Mock(), Mock())
+    package_collection = PackageCollection(None, {}, Mock(), Mock(), Mock())
 
     with patch.object(Indexer, 'get_by_identifier') as get_by_identifier:
         package_collection.get_by_identifier('@default/name')
@@ -64,7 +64,7 @@ def test_get_package_by_identifier() -> None:
 
 
 def test_get_package_by_identifier_and_version() -> None:
-    package_collection = PackageCollection(None, {}, Mock(), Mock())
+    package_collection = PackageCollection(None, {}, Mock(), Mock(), Mock())
 
     # Package does exist.
     with patch.object(Indexer, 'get_by_identifier_and_version') as get_by_identifier_and_version:
@@ -81,7 +81,7 @@ def test_get_package_by_identifier_and_version() -> None:
 
 
 def test_get_packages() -> None:
-    package_collection = PackageCollection(None, {}, Mock(), Mock())
+    package_collection = PackageCollection(None, {}, Mock(), Mock(), Mock())
 
     # Package does exist.
     with patch.object(Indexer, 'get_packages') as get_packages:
@@ -91,7 +91,7 @@ def test_get_packages() -> None:
 
 async def test_notify_indexer_on_cache_deletion(tmp_path_factory: TempPathFactory) -> None:
     cache = FileLimitLRU(tmp_path_factory.mktemp('qpy'), 100)
-    PackageCollection(None, {}, cache, Mock())
+    PackageCollection(None, {}, Mock(), cache, Mock())
 
     # The callback should unregister the package from the indexer.
     with patch.object(Indexer, 'unregister_package') as unregister_package:

--- a/tests/collector/test_repo_collector.py
+++ b/tests/collector/test_repo_collector.py
@@ -11,7 +11,7 @@ from tests.test_data.factories import RepoMetaFactory
 
 
 async def test_update_gets_called_periodically_after_start() -> None:
-    collector = RepoCollector(AsyncMock(), "", timedelta(seconds=0.1), AsyncMock())
+    collector = RepoCollector('', timedelta(seconds=0.1), AsyncMock(), AsyncMock(), AsyncMock())
     with patch.object(collector, 'update') as update:
         async with collector:
             await sleep(0.25)
@@ -19,7 +19,7 @@ async def test_update_gets_called_periodically_after_start() -> None:
 
 
 async def test_update_downloads_packages_only_on_newer_package_index() -> None:
-    collector = RepoCollector(AsyncMock(), "", Mock(), AsyncMock())
+    collector = RepoCollector('', Mock(), AsyncMock(), AsyncMock(), AsyncMock())
     with patch.object(collector, '_repository') as repository:
         # Initial update.
         repository.get_packages = AsyncMock(return_value={})
@@ -52,7 +52,7 @@ async def test_update_downloads_packages_only_on_newer_package_index() -> None:
 ])
 async def test_package_index_gets_updated(first_update: list[str], second_update: list[str]) -> None:
     indexer = AsyncMock()
-    collector = RepoCollector(AsyncMock(), "", Mock(), indexer)
+    collector = RepoCollector('', Mock(), AsyncMock(), AsyncMock(), indexer)
 
     first_packages = {package_hash: Mock() for package_hash in first_update}
     second_packages = {package_hash: Mock() for package_hash in second_update}
@@ -84,13 +84,13 @@ async def test_package_index_gets_updated(first_update: list[str], second_update
 
 
 async def test_get_path_raises_file_not_found_error_if_package_does_not_exist() -> None:
-    collector = RepoCollector(AsyncMock(), "", Mock(), AsyncMock())
+    collector = RepoCollector('', Mock(), AsyncMock(), AsyncMock(), AsyncMock())
     with pytest.raises(FileNotFoundError):
         await collector.get_path(Mock())
 
 
 async def test_get_path_raises_file_not_found_error_on_download_error() -> None:
-    collector = RepoCollector(AsyncMock(), "", Mock(), AsyncMock())
+    collector = RepoCollector('', Mock(), AsyncMock(), AsyncMock(), AsyncMock())
 
     package = Mock()
 
@@ -108,7 +108,7 @@ async def test_get_path_raises_file_not_found_error_on_download_error() -> None:
 
 async def test_get_path_caches_package() -> None:
     cache = AsyncMock()
-    collector = RepoCollector(cache, "", Mock(), AsyncMock())
+    collector = RepoCollector('', Mock(), cache, AsyncMock(), AsyncMock())
 
     package = Mock()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ from questionpy_common.constants import KiB
 
 from questionpy_server.app import QPyServer
 from questionpy_server.settings import Settings, WebserviceSettings, PackageCacheSettings, CollectorSettings, \
-    QuestionStateCacheSettings, WorkerSettings
+    QuestionStateCacheSettings, WorkerSettings, RepoIndexCacheSettings
 from questionpy_server.utils.manfiest import ComparableManifest
 
 
@@ -49,15 +49,13 @@ PACKAGE_2 = TestPackage(package_dir / 'package_2.qpy')
 
 @pytest.fixture
 def qpy_server(tmp_path_factory: TempPathFactory) -> QPyServer:
-    package_cache_directory = tmp_path_factory.mktemp('qpy_package_cache')
-    question_state_cache_directory = tmp_path_factory.mktemp('qpy_question_state_cache')
-
     server = QPyServer(Settings(
         config_files=(),
         webservice=WebserviceSettings(listen_address="127.0.0.1", listen_port=0),
         worker=WorkerSettings(),
-        cache_package=PackageCacheSettings(directory=package_cache_directory),
-        cache_question_state=QuestionStateCacheSettings(directory=question_state_cache_directory),
+        cache_package=PackageCacheSettings(directory=tmp_path_factory.mktemp('qpy_package_cache')),
+        cache_question_state=QuestionStateCacheSettings(directory=tmp_path_factory.mktemp('qpy_question_state_cache')),
+        cache_repo_index=RepoIndexCacheSettings(directory=tmp_path_factory.mktemp('qpy_repo_index_cache')),
         collector=CollectorSettings()
     ))
 

--- a/tests/repository/test_repository.py
+++ b/tests/repository/test_repository.py
@@ -1,21 +1,37 @@
 # pylint: disable=redefined-outer-name
-
+import logging
 from json import dumps
 from unittest.mock import patch, Mock, ANY
 from gzip import compress
 from urllib.parse import urljoin
 
+import pytest
 from _pytest.tmpdir import TempPathFactory
 
 from questionpy_common.constants import KiB
 
-from questionpy_server.cache import FileLimitLRU
+from questionpy_server.cache import FileLimitLRU, SizeError
 from questionpy_server.repository import Repository, RepoMeta, RepoPackage, RepoPackageIndex
 from questionpy_server.utils.manfiest import ComparableManifest, semver_encoder
 from tests.test_data.factories import RepoMetaFactory, RepoPackageVersionsFactory, ManifestFactory
 
 
 REPO_URL = 'https://example.com/repo/'
+REPO_PACKAGE_VERSIONS_0 = RepoPackageVersionsFactory.build(
+    manifest={
+        'short_name': 'package_1',
+        'namespace': 'namespace_1',
+    },
+    versions=[{'sha256': '2', 'version': '3.0.0', 'api_version': '3.0'}]
+)
+REPO_PACKAGE_VERSIONS_1 = RepoPackageVersionsFactory.build(
+    manifest={
+        'short_name': 'package_0',
+        'namespace': 'namespace_0',
+    },
+    versions=[{'sha256': '0', 'version': '1.0.0', 'api_version': '1.0'},
+              {'sha256': '1', 'version': '2.0.0', 'api_version': '2.0'}]
+)
 
 
 async def test_get_meta() -> None:
@@ -35,29 +51,9 @@ async def test_get_meta() -> None:
 
 
 async def test_get_packages(tmp_path_factory: TempPathFactory) -> None:
-    package_versions_0 = {
-        'manifest': {
-            'short_name': 'package_0',
-            'namespace': 'namespace_0',
-        },
-        'versions': [{'sha256': '0', 'version': '1.0.0', 'api_version': '1.0'},
-                     {'sha256': '1', 'version': '2.0.0', 'api_version': '2.0'}],
-    }
-
-    package_versions_1 = {
-        'manifest': {
-            'short_name': 'package_1',
-            'namespace': 'namespace_1',
-        },
-        'versions': [{'sha256': '2', 'version': '3.0.0', 'api_version': '3.0'}],
-    }
-
     repository = Repository(REPO_URL, FileLimitLRU(tmp_path_factory.mktemp('qpy'), 100 * KiB))
 
-    package_index = RepoPackageIndex(packages=[
-                        RepoPackageVersionsFactory().build(**package_versions_0),  # type: ignore[arg-type]
-                        RepoPackageVersionsFactory().build(**package_versions_1)   # type: ignore[arg-type]
-                    ])
+    package_index = RepoPackageIndex(packages=[REPO_PACKAGE_VERSIONS_0, REPO_PACKAGE_VERSIONS_1])
 
     with patch('questionpy_server.repository.download') as mock:
         parsed = dumps(package_index, default=semver_encoder)
@@ -88,19 +84,9 @@ async def test_get_packages(tmp_path_factory: TempPathFactory) -> None:
 
 
 async def test_get_packages_cached(tmp_path_factory: TempPathFactory) -> None:
-    package_versions = {
-        'manifest': {
-            'short_name': 'package_1',
-            'namespace': 'namespace_1',
-        },
-        'versions': [{'sha256': '2', 'version': '3.0.0', 'api_version': '3.0'}],
-    }
-
     cache = FileLimitLRU(tmp_path_factory.mktemp('qpy'), 100 * KiB)
     repository = Repository(REPO_URL, cache)
-    package_index = RepoPackageIndex(packages=[
-        RepoPackageVersionsFactory().build(**package_versions)  # type: ignore[arg-type]
-    ])
+    package_index = RepoPackageIndex(packages=[REPO_PACKAGE_VERSIONS_0])
 
     with patch('questionpy_server.repository.download') as mock_download, \
             patch.object(cache, 'put', wraps=cache.put) as mock_put:
@@ -118,6 +104,27 @@ async def test_get_packages_cached(tmp_path_factory: TempPathFactory) -> None:
         mock_get.assert_called_once_with(meta.sha256)
 
     assert index_1 == index_2
+
+
+async def test_log_warning_when_package_index_is_too_big_for_cache(tmp_path_factory: TempPathFactory,
+                                                                   caplog: pytest.LogCaptureFixture) -> None:
+    cache = FileLimitLRU(tmp_path_factory.mktemp('qpy'), 100 * KiB)
+    repository = Repository(REPO_URL, cache)
+    package_index = RepoPackageIndex(packages=[REPO_PACKAGE_VERSIONS_0])
+
+    with patch('questionpy_server.repository.download') as mock_download, \
+            patch.object(cache, 'put', side_effect=SizeError):
+        parsed = dumps(package_index, default=semver_encoder)
+        mock_download.return_value = compress(parsed.encode())
+
+        # Get packages.
+        meta: RepoMeta = RepoMetaFactory.build()
+
+        with caplog.at_level('WARNING'):
+            await repository.get_packages(meta)
+
+        assert caplog.record_tuples == [('questionpy-server:repository', logging.WARNING,
+                                         f'({REPO_URL}): Package index is too big to be cached.')]
 
 
 async def test_get_package() -> None:


### PR DESCRIPTION
Closes #53.

Eventuell könnte man folgende Punkte ändern:
- Die `PACKAGES.json.gz` wird komprimiert im Cache abgelegt und muss beim Abrufen wieder dekomprimiert werden. Man könnte natürlich auch direkt den unkomprimierten Index cachen.
- Versuchen zwei gleiche Repositories zur selben Zeit auf den Cache zuzugreifen und finden keinen Index, laden beide nacheinander die selbe `PACKAGES.json.gz` herunter. Das liegt an der aktuellen Implementierung des `FileLimitLRU`, die bei einem Aufruf von `get()` nicht wartet, bis ein `put()`-Aufruf beendet wurde. Ich würde vorschlagen, den Cache mit dieser Funktionalität zu erweitern (vielleicht mit einem weiteren Argument: `get(..., wait: bool = False`)
