### PR TITLE
Entferne question_state Caching

### DIFF
--- a/config.example.ini
+++ b/config.example.ini
@@ -39,13 +39,6 @@
 # The path of the cache (relative or absolute)
 #path = cache/packages
 
-[cache_question_state]
-# Maximum cache size
-#size = 20 MiB
-
-# The path of the cache (relative or absolute)
-#path = cache/question_states
-
 [cache_repo_index]
 # Maximum cache size
 #size = 200 MiB

--- a/docs/qppe.yaml
+++ b/docs/qppe.yaml
@@ -50,13 +50,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/QuestionStateHash"
+              $ref: "#/components/schemas/RequestBaseData"
           multipart/form-data:
             schema:
               type: object
               properties:
                 main:
-                  $ref: "#/components/schemas/QuestionStateHash"
+                  $ref: "#/components/schemas/RequestBaseData"
                 package:
                   type: string
                   format: binary
@@ -87,7 +87,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PackageQuestionStateNotFound"
+                $ref: "#/components/schemas/PackageNotFound"
 
   /packages/{package_hash}/question:
     parameters:
@@ -140,7 +140,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PackageQuestionStateNotFound"
+                $ref: "#/components/schemas/PackageNotFound"
 
   /packages/{package_hash}/question/migrate:
     parameters:
@@ -152,10 +152,6 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
-            schema:
-              type: string
-              description: Question state that was created by another package or another version.
           multipart/form-data:
             schema:
               type: object
@@ -189,7 +185,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PackageQuestionStateNotFound"
+                $ref: "#/components/schemas/PackageNotFound"
 
   /packages/{package_hash}/attempt/start:
     parameters:
@@ -200,9 +196,6 @@ paths:
       summary: Start an attempt
       requestBody:
         content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/AttemptStartArguments"
           multipart/form-data:
             schema:
               type: object
@@ -216,7 +209,7 @@ paths:
                 question_state:
                   type: string
                   description: Question state that was previously returned by the question endpoint.
-              required: [ main ]
+              required: [ main, question_state ]
       responses:
         201:
           description: Attempt started data
@@ -232,7 +225,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PackageQuestionStateNotFound"
+                $ref: "#/components/schemas/PackageNotFound"
 
   /packages/{package_hash}/attempt/view:
     parameters:
@@ -243,9 +236,6 @@ paths:
       summary: View an attempt
       requestBody:
         content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/AttemptViewArguments"
           multipart/form-data:
             schema:
               type: object
@@ -259,7 +249,7 @@ paths:
                 question_state:
                   type: string
                   description: Question state that was previously returned by the question endpoint.
-              required: [ main ]
+              required: [ main, question_state ]
       responses:
         201:
           description: Attempt view data
@@ -280,9 +270,6 @@ paths:
       summary: Score an attempt
       requestBody:
         content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/AttemptScoreArguments"
           multipart/form-data:
             schema:
               type: object
@@ -296,7 +283,7 @@ paths:
                 question_state:
                   type: string
                   description: Question state that was previously returned by the question endpoint.
-              required: [ main ]
+              required: [ main, question_state ]
       responses:
         201:
           description: Scored attempt data
@@ -473,36 +460,20 @@ components:
             - OPT_1
             - OPT_2
 
-    QuestionStateHash:
+    RequestBaseData:
       type: object
       properties:
-        question_state_hash:
-          type: string
-          description: SHA256 hash of question state JSON data
         context:
           type: integer
           description: Some context information where the question is located (e.g. course or quiz/test id).
           nullable: true
           default: null
-      required: [ question_state_hash ]
-
-    OptionalQuestionStateHash:
-      type: object
-      properties:
-        question_state_hash:
-          type: string
-          description: SHA256 hash of question state JSON data
-          nullable: true
-        context:
-          type: integer
-          description: Some context information where the question is located (e.g. course or quiz/test id).
-          nullable: true
-          default: null
+      required: [ ]
 
     QuestionCreateArguments:
       description: Information that is needed to create a new question.
       allOf:
-        - $ref: "#/components/schemas/OptionalQuestionStateHash"
+        - $ref: "#/components/schemas/RequestBaseData"
         - type: object
           properties:
             form_data:
@@ -515,9 +486,6 @@ components:
         question_state:
           type: string
           description: Arbitrary values set by the question package code (LMS must store this data unmodified)
-        question_state_hash:
-          type: string
-          description: SHA256 hash of question state JSON data
         num_variants:
           type: integer
           minimum: 1
@@ -595,13 +563,13 @@ components:
           type: string
           nullable: true
           description: General feedback that is shown to everyone after scoring.
-      required: [ question_state, question_state_hash, num_variants, num_subquestions, score_min,
+      required: [ question_state, num_variants, num_subquestions, score_min,
                   score_max, scoring_method, penalty, random_guess_score, subquestions,
                   response_analysis_by_variant, render_every_view, general_feedback ]
 
     AttemptStartArguments:
       allOf:
-        - $ref: "#/components/schemas/QuestionStateHash"
+        - $ref: "#/components/schemas/RequestBaseData"
         - type: object
           properties:
             variant:
@@ -716,7 +684,7 @@ components:
 
     AttemptViewArguments:
       allOf:
-        - $ref: "#/components/schemas/QuestionStateHash"
+        - $ref: "#/components/schemas/RequestBaseData"
         - type: object
           properties:
             attempt_state:
@@ -736,7 +704,7 @@ components:
     AttemptScoreArguments:
       # nested subquestions
       allOf:
-        - $ref: "#/components/schemas/QuestionStateHash"
+        - $ref: "#/components/schemas/RequestBaseData"
         - $ref: "#/components/schemas/AttemptViewArguments"
         - type: object
           properties:
@@ -848,14 +816,12 @@ components:
           required: [ scoring_state, scoring_code, score ]
         - $ref: "#/components/schemas/Attempt"
 
-    PackageQuestionStateNotFound:
+    PackageNotFound:
       type: object
       properties:
         package_not_found:
           type: boolean
-        question_state_not_found:
-          type: boolean
-      required: [ package_not_found, question_state_not_found ]
+      required: [ package_not_found ]
 
     QuestionStateMigrationError:
       type: object

--- a/questionpy_server/api/models.py
+++ b/questionpy_server/api/models.py
@@ -40,13 +40,12 @@ class PackageInfo(BaseModel):
     tags: Optional[List[str]]
 
 
-class OptionalQuestionStateHash(BaseModel):
-    question_state_hash: Optional[str]
+class MainBaseModel(BaseModel):
+    pass
+
+
+class RequestBaseData(MainBaseModel):
     context: Optional[int] = None
-
-
-class QuestionStateHash(OptionalQuestionStateHash):
-    question_state_hash: str
 
 
 class QuestionEditFormResponse(BaseModel):
@@ -54,7 +53,7 @@ class QuestionEditFormResponse(BaseModel):
     form_data: dict[str, object]
 
 
-class QuestionCreateArguments(OptionalQuestionStateHash):
+class QuestionCreateArguments(RequestBaseData):
     form_data: dict[str, object]
 
 
@@ -80,7 +79,6 @@ class Question(BaseModel):
         use_enum_values = True
 
     question_state: str
-    question_state_hash: str
     num_variants: Annotated[int, Field(ge=1, strict=True)] = 1
     num_subquestions: Annotated[int, Field(ge=1, strict=True)] = 1
     score_min: float = 0
@@ -94,7 +92,7 @@ class Question(BaseModel):
     general_feedback: Optional[str]
 
 
-class AttemptStartArguments(QuestionStateHash):
+class AttemptStartArguments(RequestBaseData):
     variant: Annotated[int, Field(ge=1, strict=True)]
 
 
@@ -140,7 +138,7 @@ class AttemptStarted(Attempt):
     attempt_state: str
 
 
-class AttemptViewArguments(QuestionStateHash):
+class AttemptViewArguments(RequestBaseData):
     attempt_state: Json
     scoring_state: Optional[Json]
     response: Optional[Dict[str, Any]]
@@ -189,9 +187,8 @@ class AttemptScored(Attempt):
     scored_fields: Optional[List[ScoredField]]
 
 
-class PackageQuestionStateNotFound(BaseModel):
+class PackageNotFound(BaseModel):
     package_not_found: bool
-    question_state_not_found: bool
 
 
 class QuestionStateMigrationErrorCode(Enum):

--- a/questionpy_server/app.py
+++ b/questionpy_server/app.py
@@ -27,8 +27,6 @@ class QPyServer:
 
         self.package_cache = FileLimitLRU(settings.cache_package.directory, settings.cache_package.size,
                                           extension='.qpy', name='PackageCache')
-        self.question_state_cache = FileLimitLRU(settings.cache_question_state.directory,
-                                                 settings.cache_question_state.size, name='QuestionStateCache')
         self.repo_index_cache = FileLimitLRU(settings.cache_repo_index.directory, settings.cache_repo_index.size,
                                              name='RepoIndexCache')
 

--- a/questionpy_server/factories/__init__.py
+++ b/questionpy_server/factories/__init__.py
@@ -4,11 +4,11 @@
 
 from .package import PackageInfoFactory
 from .attempt import AttemptFactory, AttemptScoredFactory, AttemptStartedFactory
-from .question_state import QuestionStateHash
+from .question_state import RequestBaseDataFactory
 
 
 __all__ = [
     'PackageInfoFactory',
     'AttemptFactory', 'AttemptScoredFactory', 'AttemptStartedFactory',
-    'QuestionStateHash'
+    'RequestBaseDataFactory'
 ]

--- a/questionpy_server/factories/question_state.py
+++ b/questionpy_server/factories/question_state.py
@@ -4,8 +4,8 @@
 
 from pydantic_factories import ModelFactory
 
-from questionpy_server.api.models import QuestionStateHash
+from questionpy_server.api.models import RequestBaseData
 
 
-class QuestionStateHashFactory(ModelFactory):
-    __model__ = QuestionStateHash
+class RequestBaseDataFactory(ModelFactory):
+    __model__ = RequestBaseData

--- a/questionpy_server/misc.py
+++ b/questionpy_server/misc.py
@@ -3,33 +3,10 @@
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
 
 from hashlib import sha256
-from inspect import Parameter, signature, isclass
 from pathlib import Path
-from typing import Callable, List, Type, Tuple, Union
+from typing import Union
 
 from questionpy_common.constants import MiB
-
-from questionpy_server.types import RouteHandler, M
-
-
-def get_parameters_of_type(function: Callable, cls: type) -> List[Parameter]:
-    output = []
-    param: Parameter
-    for _, param in signature(function).parameters.items():
-        if isclass(param.annotation) and issubclass(param.annotation, cls):
-            output.append(param)
-    return output
-
-
-def get_route_model_param(route_handler: RouteHandler, model: Type[M]) -> Tuple[str, Type[M]]:
-    params = get_parameters_of_type(route_handler, model)
-    if len(params) == 0:
-        raise Exception(f"No parameter of the type `{model.__name__}` present in function "
-                        f"`{route_handler.__name__}`.")
-    if len(params) > 1:
-        raise Exception(f"More than one parameter of the type `{model.__name__}` present in function "
-                        f"`{route_handler.__name__}`.")
-    return params[0].name, params[0].annotation
 
 
 def calculate_hash(source: Union[bytes, Path]) -> str:

--- a/questionpy_server/settings.py
+++ b/questionpy_server/settings.py
@@ -92,16 +92,6 @@ class PackageCacheSettings(BaseModel):
         return value.resolve()
 
 
-class QuestionStateCacheSettings(BaseModel):
-    size: ByteSize = ByteSize(20 * MiB)
-    directory: DirectoryPath = Path('cache/question_state').resolve()
-
-    @validator('directory')
-    # pylint: disable=no-self-argument
-    def resolve_path(cls, value: Path) -> Path:
-        return value.resolve()
-
-
 class RepoIndexCacheSettings(BaseModel):
     size: ByteSize = ByteSize(200 * MiB)
     directory: DirectoryPath = Path('cache/repo_index').resolve()
@@ -207,7 +197,6 @@ class Settings(BaseSettings):
     webservice: WebserviceSettings
     worker: WorkerSettings
     cache_package: PackageCacheSettings
-    cache_question_state: QuestionStateCacheSettings
     cache_repo_index: RepoIndexCacheSettings
     collector: CollectorSettings
 

--- a/questionpy_server/worker/runtime/manager.py
+++ b/questionpy_server/worker/runtime/manager.py
@@ -74,9 +74,8 @@ class WorkerManager:
             raise MainPackageNotLoadedError()
 
         state_data: Optional[dict[str, object]] = None
-        if msg.state:
-            with msg.state.open("rb") as state_file:
-                state_data = json.load(state_file)
+        if msg.question_state:
+            state_data = json.loads(msg.question_state)
 
         definition, form_data = self.main_package.qtype_instance.get_options_form(state_data)
         return GetOptionsForm.Response(definition=definition, form_data=form_data)
@@ -86,9 +85,8 @@ class WorkerManager:
             raise MainPackageNotLoadedError()
 
         state_data: Optional[dict[str, object]] = None
-        if msg.state:
-            with msg.state.open("rb") as state_file:
-                state_data = json.load(state_file)
+        if msg.question_state:
+            state_data = json.loads(msg.question_state)
 
         question = self.main_package.qtype_instance.create_question_from_options(state_data, msg.form_data)
 

--- a/questionpy_server/worker/runtime/messages.py
+++ b/questionpy_server/worker/runtime/messages.py
@@ -3,7 +3,6 @@
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
 
 from enum import IntEnum, unique
-from pathlib import Path
 from struct import Struct
 from typing import ClassVar, Type, Optional, Any
 
@@ -109,7 +108,7 @@ class GetQPyPackageManifest(MessageToWorker):
 class GetOptionsForm(MessageToWorker):
     """Execute a QuestionPy package."""
     message_id = MessageIds.GET_OPTIONS_FORM_DEFINITION
-    state: Optional[Path]
+    question_state: Optional[str]
     """Old question state or ``None`` if the question is new."""
 
     class Response(MessageToServer):
@@ -121,7 +120,7 @@ class GetOptionsForm(MessageToWorker):
 
 class CreateQuestionFromOptions(MessageToWorker):
     message_id = MessageIds.CREATE_QUESTION
-    state: Optional[Path]
+    question_state: Optional[str]
     """Old question state or ``None`` if the question is new."""
     form_data: dict[str, object]
 

--- a/questionpy_server/worker/worker/__init__.py
+++ b/questionpy_server/worker/worker/__init__.py
@@ -66,24 +66,23 @@ class Worker(ABC):
         """Get manifest of the main package in the worker."""
 
     @abstractmethod
-    async def get_options_form(self, question_state: Optional[Path]) -> tuple[OptionsFormDefinition, dict[str, object]]:
+    async def get_options_form(self, question_state: Optional[bytes]) ->\
+            tuple[OptionsFormDefinition, dict[str, object]]:
         """Get the form used to create a new or edit an existing question.
 
         Args:
-            question_state: The path to a file containing the current question state if editing, or ``None`` if creating
-                a new question.
+            question_state: The current question state if editing, or ``None`` if creating a new question.
 
         Returns:
              Tuple of the form definition and the current data of the inputs.
         """
 
     @abstractmethod
-    async def create_question_from_options(self, old_state: Optional[Path], form_data: dict[str, object]) -> Question:
+    async def create_question_from_options(self, old_state: Optional[bytes], form_data: dict[str, object]) -> Question:
         """Create or update the question (state) with the form data from a submitted question edit form.
 
         Args:
-            old_state: The path to a file containing the current question state if editing, or ``None`` if creating a
-                new question.
+            old_state: The current question state if editing, or ``None`` if creating a new question.
             form_data: Form data from a submitted question edit form.
 
         Returns:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ from questionpy_common.constants import KiB
 
 from questionpy_server.app import QPyServer
 from questionpy_server.settings import Settings, GeneralSettings, WebserviceSettings, PackageCacheSettings, \
-    CollectorSettings, QuestionStateCacheSettings, WorkerSettings, RepoIndexCacheSettings
+    CollectorSettings, WorkerSettings, RepoIndexCacheSettings
 from questionpy_server.utils.manfiest import ComparableManifest
 
 
@@ -59,7 +59,6 @@ def qpy_server(tmp_path_factory: TempPathFactory) -> QPyServer:
         webservice=WebserviceSettings(listen_address="127.0.0.1", listen_port=0),
         worker=WorkerSettings(),
         cache_package=PackageCacheSettings(directory=tmp_path_factory.mktemp('qpy_package_cache')),
-        cache_question_state=QuestionStateCacheSettings(directory=tmp_path_factory.mktemp('qpy_question_state_cache')),
         cache_repo_index=RepoIndexCacheSettings(directory=tmp_path_factory.mktemp('qpy_repo_index_cache')),
         collector=CollectorSettings()
     ))

--- a/tests/test_data/question_state/main.json
+++ b/tests/test_data/question_state/main.json
@@ -1,4 +1,3 @@
 {
-  "question_state_hash": "e6a9f487634bcc3b7e443877d6b36ecc5e5168f35729b9797ad37c3caa979769",
   "context": null
 }

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -23,39 +23,9 @@ QUESTION_STATE_REQUEST = (path / 'main.json').read_text()
 
 
 async def test_optional_question_state(client: TestClient) -> None:
-    # Even though the question state is optional, it
-    # ...is still required to be valid JSON.
+    # Even though the question state is optional, the body is still required to be valid JSON.
     res = await client.request(METHOD, URL, data=b"{not_valid!}", headers={"Content-Type": "application/json"})
     assert res.status == 400
-
-    # ...should return the status code 404 with 'question_state_not_found: True'.
-    res = await client.request(METHOD, URL, data=QUESTION_STATE_REQUEST, headers={"Content-Type": "application/json"})
-    res_data = await res.json()
-    assert res_data == {"package_not_found": True, "question_state_not_found": True}
-
-    # ...should return the status code 200 if a package is provided and question_state_hash is empty.
-    with PACKAGE.open('rb') as file:
-        payload = FormData()
-        payload.add_field('main', '{"question_state_hash": null, "context": null}', content_type="application/json")
-        payload.add_field('package', file, filename=PACKAGE.name)
-
-        res = await client.request(METHOD, URL, data=payload)
-
-    assert res.status == 200
-    res_data = await res.json()
-    OptionsFormDefinition(**res_data)
-
-    # ...should return 404 with 'question_state_not_found: True' if question_state_hash does not exist and is not empty.
-    with PACKAGE.open('rb') as file:
-        payload = FormData()
-        payload.add_field('main', '{"question_state_hash": "not_valid", "context": null}')
-        payload.add_field('package', file, filename=PACKAGE.name)
-
-        res = await client.request(METHOD, URL, data=payload)
-
-    assert res.status == 404
-    res_data = await res.json()
-    assert res_data == {"package_not_found": False, "question_state_not_found": True}
 
 
 async def test_no_package(client: TestClient) -> None:
@@ -68,7 +38,7 @@ async def test_no_package(client: TestClient) -> None:
 
     assert res.status == 404
     res_data = await res.json()
-    assert res_data == {"package_not_found": True, "question_state_not_found": False}
+    assert res_data == {"package_not_found": True}
 
 
 async def test_data_gets_cached(client: TestClient) -> None:
@@ -84,14 +54,9 @@ async def test_data_gets_cached(client: TestClient) -> None:
     reference = await res.json()
     OptionsFormDefinition(**reference)
 
-    # Package and question state should be stored in cache.
-    res = await client.request(METHOD, URL, data=QUESTION_STATE_REQUEST, headers={"Content-Type": "application/json"})
-    assert res.status == 200
-    res_data = await res.json()
-    assert res_data == reference
-
     payload = FormData()
     payload.add_field('main', QUESTION_STATE_REQUEST)
+    payload.add_field('question_state', QUESTION_STATE)
     payload.add_field('ignore', BytesIO())  # Additional fields get ignored.
     res = await client.request(METHOD, URL, data=payload)
     assert res.status == 200

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -13,40 +13,6 @@ from questionpy_server.api.models import PackageInfo
 from tests.conftest import PACKAGE
 
 
-async def test_post_package(client: TestClient) -> None:
-    with PACKAGE.path.open('rb') as file:
-        payload = FormData()
-        payload.add_field('package', file)
-
-        res = await client.request('POST', f'/packages/{PACKAGE.hash}', data=payload)
-
-    assert res.status == 200
-    data = await res.json()
-    parse_obj_as(PackageInfo, data)
-
-
-async def test_post_package_faulty(client: TestClient) -> None:
-    # Package hash is not matching the package.
-    with PACKAGE.path.open('rb') as file:
-        payload = FormData()
-        payload.add_field('package', file)
-
-        res = await client.request('POST', f'/packages/{PACKAGE.hash + "x"}', data=payload)
-
-    assert res.status == 400
-    text = await res.text()
-    assert text.startswith('Package hash does not match')
-
-    # Request without package in payload.
-    payload = FormData()
-    payload.add_field('ignore', BytesIO())  # To force multipart/form-data.
-
-    res = await client.request('POST', f'/packages/{PACKAGE.hash}', data=payload)
-    assert res.status == 400
-    text = await res.text()
-    assert text == 'No package found in multipart/form-data'
-
-
 async def test_packages(client: TestClient) -> None:
     res = await client.request('GET', '/packages')
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -24,7 +24,6 @@ def path_with_empty_config_file(tmp_path: Path) -> Path:
         [webservice]
         [worker]
         [cache_package]
-        [cache_question_state]
         [cache_repo_index]
         [collector]
     """)


### PR DESCRIPTION
Max hatte sich ja schon länger dafür ausgesprochen, dass wir das Feature entfernen, um den Code etwas zu vereinfachen. Der `question_state` muss jetzt immer übertragen werden und sollte in der Regel hoffentlich nur ein paar KB groß sein.

Ich habe das jetzt umgesetzt und noch ein paar weitere kleinere Vereinfachungen vorgenommen. Beispielsweise indem die Route-Funktionen ihre Argumente jetzt `data`, `question_state` und `package` nennen müssen. Der Decorator `ensure_package_and_question_state_exist` kann sich dadurch die Funktionen leichter ansehen und entscheiden, ob ein HTTP-Request alle von der Funktion benötigten Daten enthält.