### PR TITLE
refactor: deprecated pydantic v2 methods

### DIFF
--- a/questionpy_server/package.py
+++ b/questionpy_server/package.py
@@ -134,7 +134,7 @@ class Package:
         """
 
         if not self._info:
-            tmp = self.manifest.dict()
+            tmp = self.manifest.model_dump()
             tmp['version'] = str(tmp['version'])
             self._info = PackageInfo(**tmp, package_hash=self.hash)
         return self._info

--- a/questionpy_server/repository/__init__.py
+++ b/questionpy_server/repository/__init__.py
@@ -54,7 +54,7 @@ class Repository:
                 self._log.warning('Package index is too big to be cached.')
 
         raw_index = decompress(raw_index_zip)
-        index = RepoPackageIndex.parse_raw(raw_index)
+        index = RepoPackageIndex.model_validate_json(raw_index)
 
         # Combine general manifest of a package with correct (api-)version.
         packages_dict: dict[str, RepoPackage] = {}

--- a/questionpy_server/repository/models.py
+++ b/questionpy_server/repository/models.py
@@ -85,7 +85,7 @@ class RepoPackage:
             repo_package_version: version of the package
         """
         # Replace package version and api version with actual versions.
-        modified_manifest = manifest.copy(deep=True)
+        modified_manifest = manifest.model_copy(deep=True)
         modified_manifest.version = repo_package_version.version
         modified_manifest.api_version = repo_package_version.api_version
 

--- a/questionpy_server/web.py
+++ b/questionpy_server/web.py
@@ -42,7 +42,7 @@ def json_response(data: Union[Sequence[BaseModel], BaseModel], status: int = 200
     if isinstance(data, Sequence):
         json_list = f'[{",".join(x.json() for x in data)}]'
         return Response(text=json_list, status=status, content_type='application/json')
-    return Response(text=data.json(), status=status, content_type='application/json')
+    return Response(text=data.model_dump_json(), status=status, content_type='application/json')
 
 
 def create_model_from_json(json: Union[object, str], param_class: Type[M]) -> M:
@@ -248,7 +248,7 @@ def ensure_package_and_question_state_exist(_func: Optional[RouteHandler] = None
             if package is None:
                 if package_hash:
                     raise HTTPNotFound(
-                        text=PackageNotFound(package_not_found=True).json(),
+                        text=PackageNotFound(package_not_found=True).model_dump_json(),
                         content_type='application/json'
                     )
 

--- a/tests/repository/test_repository.py
+++ b/tests/repository/test_repository.py
@@ -39,7 +39,7 @@ async def test_get_meta() -> None:
     repository = Repository(REPO_URL, Mock())
     with patch('questionpy_server.repository.download') as mock:
         expected = RepoMetaFactory.build()
-        mock.return_value = expected.json().encode()
+        mock.return_value = expected.model_dump_json().encode()
 
         # Get meta.
         meta = await repository.get_meta()
@@ -76,7 +76,7 @@ async def test_get_packages(tmp_path_factory: TempPathFactory) -> None:
                 package = index[versions.sha256]
 
                 # Combine manifest with version and api_version.
-                expected_manifest = packages.manifest.dict()
+                expected_manifest = packages.manifest.model_dump()
                 expected_manifest['version'] = str(versions.version)
                 expected_manifest['api_version'] = versions.api_version
 


### PR DESCRIPTION
Beim letzten PR sind mir einige Sonderheiten mit pydantic aufgefallen, die ich in diesem PR angehen will.

1. `PydanticDeprecatedSince20` Warnings beim Ausführen von pytest
2. Bei `pydantic <=2.2` treten `WorkerMemoryLimitExceededError` Fehlermeldungen auf beim `py39-pytest` Check.
3. Ab `pydantic 2.4` wird der type `FieldValidationInfo` zu `ValidationInfo` umbenannt. Das war im Changelog nicht zu finden, wird aber in diesem [Issue](https://github.com/pydantic/pydantic/issues/7667) besprochen.

- Die _deprecated_ Methoden wurden durch die neueren ersetzt. 
- Gerne können wir auch die Änderung (3.) noch vornehmen und direkt auf Version 2.4 wechseln.