### PR TITLE
Docstrings zu Google Stil wechseln

### DIFF
--- a/questionpy_server/misc.py
+++ b/questionpy_server/misc.py
@@ -10,11 +10,13 @@ from questionpy_common.constants import MiB
 
 
 def calculate_hash(source: Union[bytes, Path]) -> str:
-    """
-    Calculates the sha256 of either bytes or a file.
+    """Calculates the sha256 of either bytes or a file.
 
-    :param source: bytes or path to file
-    :return: the sha256
+    Args:
+        source (Union[bytes, Path]) : bytes or path to file
+
+    Returns:
+        str: the sha256
     """
     sha = sha256()
 

--- a/questionpy_server/repository/__init__.py
+++ b/questionpy_server/repository/__init__.py
@@ -28,7 +28,8 @@ class Repository:
         """
         Downloads and verifies metadata.
 
-        :return: metadata
+        Returns:
+            RepoMeta: Metadata
         """
         meta = await download(self._url_meta)
         # TODO: verify downloaded data
@@ -38,8 +39,11 @@ class Repository:
         """
         Downloads and verifies package index.
 
-        :param meta: metadata
-        :return: package index, where keys are package hashes
+        Args:
+            meta (RepoMeta): Metadata
+
+        Returns:
+            dict[str, RepoPackage]: package index, where keys are package hashes
         """
         try:
             # Try to get the index from cache.
@@ -70,8 +74,11 @@ class Repository:
         """
         Download a specific package from the repository.
 
-        :param package: repository package
-        :return: raw package bytes
+        Args:
+            package (RepoPackage): repository package
+
+        Returns:
+            bytes: raw package bytes
         """
 
         url = urljoin(self._url_base, package.path)

--- a/questionpy_server/repository/helper.py
+++ b/questionpy_server/repository/helper.py
@@ -18,10 +18,13 @@ async def download(url: str, size: int = -1, expected_hash: Optional[str] = None
     Downloads data from the given `url` and validates it if `expected_hash` is not `None`.
     The download size can be limited by setting `size`.
 
-    :param url: url of the data
-    :param size: maximum amount of bytes to be downloaded
-    :param expected_hash: data must have this hash
-    :return:
+    Args:
+        url (str): url of the data
+        size (int): maximum amount of bytes to be downloaded
+        expected_hash (Optional[str]): data must have this hash. Defaults to None.
+
+    Returns:
+        bytes: data
     """
     async with ClientSession(auto_decompress=False, raise_for_status=True) as session:
         try:


### PR DESCRIPTION
Die letzten Docstrings wurden in den Google Docstring Stil gefasst.