### PR TITLE
Question State sollte `str` sein

### DIFF
--- a/questionpy_server/api/routes.py
+++ b/questionpy_server/api/routes.py
@@ -54,7 +54,8 @@ async def post_options(request: web.Request, package: Package, question_state: O
     package_path = await package.get_path()
     worker: Worker
     async with qpyserver.worker_pool.get_worker(ZipPackageLocation(package_path), 0, data.context) as worker:
-        definition, form_data = await worker.get_options_form(RequestUser(["de", "en"]), question_state)
+        definition, form_data = await worker.get_options_form(RequestUser(["de", "en"]),
+                                                              question_state.decode() if question_state else None)
 
     return json_response(data=QuestionEditFormResponse(definition=definition, form_data=form_data))
 
@@ -119,7 +120,9 @@ async def post_question(request: web.Request, data: QuestionCreateArguments,
     package_path = await package.get_path()
     worker: Worker
     async with qpyserver.worker_pool.get_worker(ZipPackageLocation(package_path), 0, data.context) as worker:
-        question = await worker.create_question_from_options(RequestUser(["de", "en"]), question_state, data.form_data)
+        question = await worker.create_question_from_options(RequestUser(["de", "en"]),
+                                                             question_state.decode() if question_state else None,
+                                                             data.form_data)
 
     return json_response(data=question)
 

--- a/questionpy_server/worker/worker/__init__.py
+++ b/questionpy_server/worker/worker/__init__.py
@@ -68,7 +68,7 @@ class Worker(ABC):
         """Get manifest of the main package in the worker."""
 
     @abstractmethod
-    async def get_options_form(self, request_user: RequestUser, question_state: Optional[bytes]) -> \
+    async def get_options_form(self, request_user: RequestUser, question_state: Optional[str]) -> \
             tuple[OptionsFormDefinition, dict[str, object]]:
         """Get the form used to create a new or edit an existing question.
 
@@ -81,7 +81,7 @@ class Worker(ABC):
         """
 
     @abstractmethod
-    async def create_question_from_options(self, request_user: RequestUser, old_state: Optional[bytes],
+    async def create_question_from_options(self, request_user: RequestUser, old_state: Optional[str],
                                            form_data: dict[str, object]) -> QuestionCreated:
         """Create or update the question (state) with the form data from a submitted question edit form.
 

--- a/questionpy_server/worker/worker/base.py
+++ b/questionpy_server/worker/worker/base.py
@@ -142,17 +142,15 @@ class BaseWorker(Worker, ABC):
         ret = await self._send_and_wait_response(msg, GetQPyPackageManifest.Response)
         return ComparableManifest(**ret.manifest.model_dump())
 
-    async def get_options_form(self, request_user: RequestUser, question_state: Optional[bytes]) \
+    async def get_options_form(self, request_user: RequestUser, question_state: Optional[str]) \
             -> tuple[OptionsFormDefinition, dict[str, object]]:
-        question_state_str = None if question_state is None else question_state.decode()
-        msg = GetOptionsForm(question_state=question_state_str, request_user=request_user)
+        msg = GetOptionsForm(question_state=question_state, request_user=request_user)
         ret = await self._send_and_wait_response(msg, GetOptionsForm.Response)
         return ret.definition, ret.form_data
 
-    async def create_question_from_options(self, request_user: RequestUser, old_state: Optional[bytes],
+    async def create_question_from_options(self, request_user: RequestUser, old_state: Optional[str],
                                            form_data: dict[str, object]) -> QuestionCreated:
-        question_state_str = None if old_state is None else old_state.decode()
-        msg = CreateQuestionFromOptions(question_state=question_state_str, form_data=form_data,
+        msg = CreateQuestionFromOptions(question_state=old_state, form_data=form_data,
                                         request_user=request_user)
         ret = await self._send_and_wait_response(msg, CreateQuestionFromOptions.Response)
 


### PR DESCRIPTION
Der Einheitlichkeit halber sollte der `question_state` ein string sein, zumindest bei dem `worker`.

Bei den Routen habe ich es mal als `bytes` gelassen, weil ich mich da nicht an den `@ensure_package_and_question_state_exist` decorator rangetraut habe.