### PR TITLE
fix: environment variable count

### DIFF
--- a/questionpy_server/settings.py
+++ b/questionpy_server/settings.py
@@ -199,13 +199,13 @@ class CustomEnvSettingsSource(EnvSettingsSource):
     def __init__(self, settings_cls: type[BaseSettings]) -> None:
         super().__init__(settings_cls)
 
-    def _get_settings(self, settings: dict[str, Any], result: set | None = None, parent: str = "") -> set[str]:
+    def _format_settings(self, settings: dict[str, Any], result: set | None = None, parent: str = "") -> set[str]:
         if result is None:
             result = set()
 
         for key, value in settings.items():
             if isinstance(value, dict):
-                self._get_settings(value, result, f"{parent}{key}->")
+                self._format_settings(value, result, f"{parent}{key}->")
             else:
                 result.add(f"{parent}{key}: {value}")
 
@@ -219,12 +219,13 @@ class CustomEnvSettingsSource(EnvSettingsSource):
     def __call__(self) -> dict[str, Any]:
         env_settings = super().__call__()
         if env_settings:
+            formatted_settings = self._format_settings(env_settings)
             _log.info(
                 "Reading settings from environment variables, %s in total. Environment variables overwrite "
                 "settings from the config file.",
-                len(env_settings),
+                len(formatted_settings),
             )
-            _log.debug("Following settings were read from environment variables: %s", self._get_settings(env_settings))
+            _log.debug("Following settings were read from environment variables: %s", sorted(formatted_settings))
         return env_settings
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -40,7 +40,7 @@ def test_env_settings_source_wrapper(caplog: pytest.LogCaptureFixture) -> None:
     settings_wrapper = CustomEnvSettingsSource(MagicMock())
 
     with patch.object(
-        EnvSettingsSource, "__call__", return_value={"test": "value", "nested": {"test": "value"}}
+        EnvSettingsSource, "__call__", return_value={"beta": "1", "alpha": {"gamma": "3", "delta": "2"}}
     ) as mock:
         # Test that the wrapper calls the underlying source.
         settings_wrapper()
@@ -50,7 +50,7 @@ def test_env_settings_source_wrapper(caplog: pytest.LogCaptureFixture) -> None:
     assert caplog.record_tuples[0] == (
         "questionpy-server:settings",
         logging.INFO,
-        "Reading settings from environment variables, 2 in total. Environment variables "
+        "Reading settings from environment variables, 3 in total. Environment variables "
         "overwrite settings from the config file.",
     )
 
@@ -58,7 +58,7 @@ def test_env_settings_source_wrapper(caplog: pytest.LogCaptureFixture) -> None:
     assert logger_name == "questionpy-server:settings"
     assert level == logging.DEBUG
     assert message.startswith("Following settings were read from environment variables: ")
-    assert message.endswith(("{'test: value', 'nested->test: value'}", "{'nested->test: value', 'test: value'}"))
+    assert message.endswith("['alpha->delta: 2', 'alpha->gamma: 3', 'beta: 1']")
 
 
 def test_env_var_has_higher_priority_than_config_file(path_with_empty_config_file: Path) -> None:


### PR DESCRIPTION
Mir ist beim Starten des Servers ein kleiner Bug aufgefallen:

Die Settings werden in `env_settings` als `dict` im Format `{'_section_': {'_key_': '_value'}}` abgelegt.
`len(env_settings)` gibt daher nur die Anzahl der <em>section</em>s zurück und nicht die Anzahl der _key_-_value_-Paare.
So wurde z.B. beim Setzen der Umgebungsvariablen `QPY_WEBSERVICE__LISTEN_ADDRESS=0.0.0.0` und `QPY_WEBSERVICE__PORT=9020`, `[...]Reading settings from environment variables, 1 in total.[...]` geloggt.

Damit die Ausgabe der gelesenen Umgebungsvariablen etwas übersichtlicher ist, werden diese sortiert.