### PR TITLE
Stubs für `Worker.get_static_file` und `Worker.get_static_file_index`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -111,13 +111,13 @@ frozenlist = ">=1.1.0"
 
 [[package]]
 name = "annotated-types"
-version = "0.6.0"
+version = "0.7.0"
 description = "Reusable constraint types to use with typing.Annotated"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "annotated_types-0.6.0-py3-none-any.whl", hash = "sha256:0641064de18ba7a25dee8f96403ebc39113d0cb953a01429249d5c7564666a43"},
-    {file = "annotated_types-0.6.0.tar.gz", hash = "sha256:563339e807e53ffd9c267e99fc6d9ea23eb8443c08f112651963e24e22f84a5d"},
+    {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
+    {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
 ]
 
 [[package]]
@@ -787,13 +787,13 @@ yaml = ["pyyaml (>=6.0.1)"]
 
 [[package]]
 name = "pytest"
-version = "8.2.0"
+version = "8.2.1"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pytest-8.2.0-py3-none-any.whl", hash = "sha256:1733f0620f6cda4095bbf0d9ff8022486e91892245bb9e7d5542c018f612f233"},
-    {file = "pytest-8.2.0.tar.gz", hash = "sha256:d507d4482197eac0ba2bae2e9babf0672eb333017bcedaa5fb1a3d42c1174b3f"},
+    {file = "pytest-8.2.1-py3-none-any.whl", hash = "sha256:faccc5d332b8c3719f40283d0d44aa5cf101cec36f88cde9ed8f2bc0538612b1"},
+    {file = "pytest-8.2.1.tar.gz", hash = "sha256:5046e5b46d8e4cac199c373041f26be56fdb81eb4e67dc11d4e10811fc3408fd"},
 ]
 
 [package.dependencies]
@@ -826,13 +826,13 @@ testing = ["coverage (==6.2)", "mypy (==0.931)"]
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.23.6"
+version = "0.23.7"
 description = "Pytest support for asyncio"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pytest-asyncio-0.23.6.tar.gz", hash = "sha256:ffe523a89c1c222598c76856e76852b787504ddb72dd5d9b6617ffa8aa2cde5f"},
-    {file = "pytest_asyncio-0.23.6-py3-none-any.whl", hash = "sha256:68516fdd1018ac57b846c9846b954f0393b26f094764a28c955eabb0536a4e8a"},
+    {file = "pytest_asyncio-0.23.7-py3-none-any.whl", hash = "sha256:009b48127fbe44518a547bddd25611551b0e43ccdbf1e67d12479f569832c20b"},
+    {file = "pytest_asyncio-0.23.7.tar.gz", hash = "sha256:5f5c72948f4c49e7db4f29f2521d4031f1c27f86e57b046126654083d4770268"},
 ]
 
 [package.dependencies]
@@ -886,7 +886,7 @@ cli = ["click (>=5.0)"]
 
 [[package]]
 name = "questionpy-common"
-version = "0.2.1"
+version = "0.2.2"
 description = "Common classes and functions for QuestionPy"
 optional = false
 python-versions = "^3.11"
@@ -900,8 +900,8 @@ pydantic = "^2.6.4"
 [package.source]
 type = "git"
 url = "https://github.com/questionpy-org/questionpy-common.git"
-reference = "0a2e08a505ac17f0f15eb82bec61cebb415104a7"
-resolved_reference = "0a2e08a505ac17f0f15eb82bec61cebb415104a7"
+reference = "608274c188c1dbf7d0ffb156ee87322b10e9f6b8"
+resolved_reference = "608274c188c1dbf7d0ffb156ee87322b10e9f6b8"
 
 [[package]]
 name = "ruff"
@@ -953,13 +953,13 @@ files = [
 
 [[package]]
 name = "types-psutil"
-version = "5.9.5.20240511"
+version = "5.9.5.20240516"
 description = "Typing stubs for psutil"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "types-psutil-5.9.5.20240511.tar.gz", hash = "sha256:2c0b22edab6c8775f4a8688e3f14cefda8793e26ddf99d61b654a0d600179087"},
-    {file = "types_psutil-5.9.5.20240511-py3-none-any.whl", hash = "sha256:7b4a12ace894c087f684ea3b4fb81964d6b941aabbae8437959616cbd9d48346"},
+    {file = "types-psutil-5.9.5.20240516.tar.gz", hash = "sha256:bb296f59fc56458891d0feb1994717e548a1bcf89936a2877df8792b822b4696"},
+    {file = "types_psutil-5.9.5.20240516-py3-none-any.whl", hash = "sha256:83146ded949a10167d9895e567b3b71e53ebc5e23fd8363eab62b3c76cce7b89"},
 ]
 
 [[package]]
@@ -1120,4 +1120,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "a17cbefe7132728db67da52439e2383cf1f984823343441112988078f050d993"
+content-hash = "b975ed557f84bc6b217925c961cf9d7041e7b834c6d6f805c1953bf92a170b57"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,13 @@ description = "QuestionPy application server"
 authors = ["Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>"]
 license = "MIT"
 homepage = "https://questionpy.org"
-version = "0.2.2"
+version = "0.2.3"
 
 [tool.poetry.dependencies]
 python = "^3.11"
 aiohttp = "^3.9.3"
 pydantic = "^2.6.4"
-questionpy-common = { git = "https://github.com/questionpy-org/questionpy-common.git", rev = "0a2e08a505ac17f0f15eb82bec61cebb415104a7" }
+questionpy-common = { git = "https://github.com/questionpy-org/questionpy-common.git", rev = "608274c188c1dbf7d0ffb156ee87322b10e9f6b8" }
 polyfactory = "^2.15.0"
 pydantic-settings = "^2.2.1"
 watchdog = "^4.0.0"

--- a/questionpy_server/worker/worker/base.py
+++ b/questionpy_server/worker/worker/base.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, TypeVar
 
 from questionpy_common.api.attempt import AttemptModel, AttemptScoredModel
 from questionpy_common.elements import OptionsFormDefinition
-from questionpy_common.environment import RequestUser, WorkerResourceLimits
+from questionpy_common.environment import PackageFile, RequestUser, WorkerResourceLimits
 from questionpy_server.api.models import AttemptStarted, QuestionCreated
 from questionpy_server.utils.manifest import ComparableManifest
 from questionpy_server.worker.exception import WorkerNotRunningError, WorkerStartError
@@ -31,7 +31,7 @@ from questionpy_server.worker.runtime.messages import (
     WorkerError,
 )
 from questionpy_server.worker.runtime.package_location import PackageLocation
-from questionpy_server.worker.worker import Worker, WorkerState
+from questionpy_server.worker.worker import PackageFileStream, Worker, WorkerState
 
 if TYPE_CHECKING:
     from questionpy_server.worker.connection import ServerToWorkerConnection
@@ -223,3 +223,9 @@ class BaseWorker(Worker, ABC):
         ret = await self._send_and_wait_response(msg, ScoreAttempt.Response)
 
         return ret.attempt_scored_model
+
+    async def get_static_file(self, path: str) -> PackageFileStream:
+        raise NotImplementedError  # TODO: Implement get_static_file.
+
+    async def get_static_file_index(self) -> dict[str, PackageFile]:
+        raise NotImplementedError  # TODO: Implement get_static_file_index.


### PR DESCRIPTION
Perspektivisch machen bestimmt streamigere Methoden auf PackageFileStream Sinn, aber ich habe es jetzt erstmal minimal gehalten.

Basiert auf <https://github.com/questionpy-org/questionpy-common/pull/32>