### PR TITLE
chore: import `Traversable` from `importlib.resources.abc`

### DIFF
--- a/questionpy_server/worker/runtime/package.py
+++ b/questionpy_server/worker/runtime/package.py
@@ -8,7 +8,7 @@ import zipfile
 from abc import ABC, abstractmethod
 from functools import cached_property
 from importlib import import_module, resources
-from importlib.abc import Traversable
+from importlib.resources.abc import Traversable
 from pathlib import Path
 from types import ModuleType
 from typing import cast


### PR DESCRIPTION
Ref: https://docs.python.org/3.12/whatsnew/3.12.html#pending-removal-in-python-3-14