### PR TITLE
#108: Lesen von statischen Dateien aus ZIP-Paketen funktioniert nicht

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,7 @@ class TestPackage(ZipPackageLocation):
 
     @contextmanager
     def as_dir_package(self) -> Iterator[DirPackageLocation]:
+        """Creates a dir package from this zip package."""
         with TemporaryDirectory() as tmp_dir, ZipFile(self.path) as package:
             package.extractall(tmp_dir)
             yield DirPackageLocation(Path(tmp_dir) / DIST_DIR)


### PR DESCRIPTION
Für den Fix hätte ich gar keinen PR erstellt, aber ich habe noch ein paar Tests hinzugefügt, die etwas komplizierter geworden sind. Schaut da gern nochmal drüber, vielleicht fällt euch ja eine einfachere Variante ein.

Fixes https://github.com/questionpy-org/questionpy-server/issues/108