### PR TITLE
Update `/packages` in QPPE

### DIFF
--- a/docs/qppe-server.yaml
+++ b/docs/qppe-server.yaml
@@ -19,7 +19,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/PackageInfo"
+                  $ref: "#/components/schemas/PackageVersionsInfo"
 
   /packages/{package_hash}:
     parameters:
@@ -458,7 +458,7 @@ components:
         type: string
 
   schemas:
-    Manifest:
+    PackageInfo:
       type: object
       properties:
         short_name:
@@ -528,14 +528,13 @@ components:
 
     PackageVersionInfo:
       allOf:
-        - $ref: '#/components/schemas/Manifest'
+        - $ref: '#/components/schemas/PackageInfo'
         - $ref: '#/components/schemas/PackageVersionSpecificInfo'
 
-    PackageInfo:
+    PackageVersionsInfo:
       properties:
         manifest:
-          allOf:
-            - $ref: '#/components/schemas/Manifest'
+          $ref: '#/components/schemas/PackageInfo'
         versions:
           type: array
           items:

--- a/docs/qppe-server.yaml
+++ b/docs/qppe-server.yaml
@@ -34,7 +34,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PackageInfo"
+                $ref: "#/components/schemas/PackageVersionInfo"
         404:
           description: Not Found
 
@@ -385,7 +385,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PackageInfo"
+                $ref: "#/components/schemas/PackageVersionInfo"
         500:
           description: Error occurred.
           content:
@@ -458,13 +458,9 @@ components:
         type: string
 
   schemas:
-    PackageInfo:
+    Manifest:
       type: object
       properties:
-        package_hash:
-          type: string
-          description: SHA256 hash of package zip
-          example: bf6f896
         short_name:
           type: string
           example: multiple_choice
@@ -476,12 +472,6 @@ components:
           example:
             en: Multiple Choice
             de: Mehrfachauswahl
-        version:
-          type: string
-          format: semver
-          # https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-          pattern: '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
-          example: 0.1.0
         type:
           type: string
           enum:
@@ -498,6 +488,7 @@ components:
           type: array
           items:
             type: string
+          example: [ en, de ]
           default: [ ]
         description:
           type: object
@@ -518,7 +509,37 @@ components:
         tags:
           type: array
           default: [ ]
-      required: [ package_hash, short_name, namespace, name, version, type, author ]
+      required: [ short_name, namespace, name, type, author ]
+
+    PackageVersionSpecificInfo:
+      type: object
+      properties:
+        package_hash:
+          type: string
+          description: SHA256 hash of package zip
+          example: bf6f896
+        version:
+          type: string
+          format: semver
+          # https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+          pattern: '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
+          example: 0.1.0
+      required: [ package_hash, version ]
+
+    PackageVersionInfo:
+      allOf:
+        - $ref: '#/components/schemas/Manifest'
+        - $ref: '#/components/schemas/PackageVersionSpecificInfo'
+
+    PackageInfo:
+      properties:
+        manifest:
+          allOf:
+            - $ref: '#/components/schemas/Manifest'
+        versions:
+          type: array
+          items:
+            $ref: '#/components/schemas/PackageVersionSpecificInfo'
 
     OptionsFormDefinition:
       type: object


### PR DESCRIPTION
Teil von #110.

Beim Aufruf von `/packages` soll ein Array mit Objekten folgender Struktur zurückgegeben werden:

```
{
    "manifest": {...}, // Manifest der aktuellsten Paketversion.
    "versions": [...]  // Sortiertes Array von {"package_hash": ..., "version": ...}-Objekten.
}
```