### PR TITLE
feat: worker respects max cpu time

### DIFF
--- a/questionpy_server/worker/__init__.py
+++ b/questionpy_server/worker/__init__.py
@@ -54,6 +54,7 @@ class Worker(ABC):
     """Interface for worker implementations."""
 
     def __init__(self, package: PackageLocation, limits: WorkerResourceLimits | None) -> None:
+        super().__init__()
         self.package = package
         self.limits = limits
         self.state = WorkerState.NOT_RUNNING

--- a/questionpy_server/worker/exception.py
+++ b/questionpy_server/worker/exception.py
@@ -1,18 +1,27 @@
 #  This file is part of the QuestionPy Server. (https://questionpy.org)
 #  The QuestionPy Server is free software released under terms of the MIT license. See LICENSE.md.
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+from questionpy_server.worker.runtime.messages import BaseWorkerError
 
 
-class WorkerNotRunningError(Exception):
+class WorkerNotRunningError(BaseWorkerError):
     pass
 
 
-class WorkerStartError(Exception):
+class WorkerStartError(BaseWorkerError):
     pass
 
 
-class WorkerCPUTimeLimitExceededError(Exception):
-    pass
+class WorkerCPUTimeLimitExceededError(BaseWorkerError):
+    def __init__(self, limit: float):
+        self.limit = limit
+        super().__init__(f"Worker has exceeded its CPU time limit of {limit} seconds and was killed.")
+
+
+class WorkerRealTimeLimitExceededError(BaseWorkerError):
+    def __init__(self, limit: float):
+        self.limit = limit
+        super().__init__(f"Worker has exceeded its real time limit of {limit} seconds and was killed.")
 
 
 class StaticFileSizeMismatchError(Exception):

--- a/questionpy_server/worker/impl/_base.py
+++ b/questionpy_server/worker/impl/_base.py
@@ -5,21 +5,29 @@
 import asyncio
 import contextlib
 import logging
-from abc import ABC
+import time
+from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 from zipfile import ZipFile
 
 from questionpy_common.api.attempt import AttemptModel, AttemptScoredModel, AttemptStartedModel
 from questionpy_common.constants import DIST_DIR
 from questionpy_common.elements import OptionsFormDefinition
-from questionpy_common.environment import RequestUser, WorkerResourceLimits
+from questionpy_common.environment import RequestUser
 from questionpy_common.manifest import Manifest, PackageFile
 from questionpy_server.models import QuestionCreated
 from questionpy_server.utils.manifest import ComparableManifest
 from questionpy_server.worker import PackageFileData, Worker, WorkerState
-from questionpy_server.worker.exception import StaticFileSizeMismatchError, WorkerNotRunningError, WorkerStartError
+from questionpy_server.worker.exception import (
+    StaticFileSizeMismatchError,
+    WorkerCPUTimeLimitExceededError,
+    WorkerNotRunningError,
+    WorkerRealTimeLimitExceededError,
+    WorkerStartError,
+)
 from questionpy_server.worker.runtime.messages import (
+    BaseWorkerError,
     CreateQuestionFromOptions,
     Exit,
     GetOptionsForm,
@@ -37,7 +45,6 @@ from questionpy_server.worker.runtime.messages import (
 from questionpy_server.worker.runtime.package_location import (
     DirPackageLocation,
     FunctionPackageLocation,
-    PackageLocation,
     ZipPackageLocation,
 )
 
@@ -64,14 +71,17 @@ class BaseWorker(Worker, ABC):
     """Base class implementing some common functionality of workers."""
 
     _worker_type = "unknown"
+    _init_worker_timeout = 2
+    _load_qpy_package_timeout = 4
 
-    def __init__(self, package: PackageLocation, limits: WorkerResourceLimits | None) -> None:
-        super().__init__(package, limits)
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
 
         self._observe_task: asyncio.Task | None = None
 
         self._connection: ServerToWorkerConnection | None = None
         self._expected_incoming_messages: list[tuple[MessageIds, asyncio.Future]] = []
+        self._receive_messages_exception: BaseException | None = None
 
     async def _initialize(self) -> None:
         """Initializes an already running worker and starts the observe task.
@@ -88,11 +98,14 @@ class BaseWorker(Worker, ABC):
                     worker_type=self._worker_type,
                 ),
                 InitWorker.Response,
+                self._init_worker_timeout,
             )
             await self.send_and_wait_for_response(
-                LoadQPyPackage(location=self.package, main=True), LoadQPyPackage.Response
+                LoadQPyPackage(location=self.package, main=True),
+                LoadQPyPackage.Response,
+                self._load_qpy_package_timeout,
             )
-        except WorkerNotRunningError as e:
+        except BaseWorkerError as e:
             msg = "Worker has exited before or during initialization."
             raise WorkerStartError(msg) from e
 
@@ -101,7 +114,9 @@ class BaseWorker(Worker, ABC):
             raise WorkerNotRunningError
         self._connection.send_message(message)
 
-    async def send_and_wait_for_response(self, message: MessageToWorker, expected_response_message: type[_M]) -> _M:
+    async def send_and_wait_for_response(
+        self, message: MessageToWorker, expected_response_message: type[_M], timeout: float | None = None
+    ) -> _M:
         self.send(message)
         fut = asyncio.get_running_loop().create_future()
         self._expected_incoming_messages.append((expected_response_message.message_id, fut))
@@ -138,7 +153,8 @@ class BaseWorker(Worker, ABC):
         finally:
             for _, future in self._expected_incoming_messages:
                 if not future.done():
-                    future.set_exception(WorkerNotRunningError())
+                    exc = self._receive_messages_exception or WorkerNotRunningError()
+                    future.set_exception(exc)
             self._expected_incoming_messages = []
 
     def _get_observation_tasks(self) -> Sequence[asyncio.Task]:
@@ -153,10 +169,14 @@ class BaseWorker(Worker, ABC):
 
     async def _observe(self) -> None:
         """Observes the tasks returned by _get_observation_tasks."""
-        pending: Sequence[asyncio.Task] = []
+        pending: set[asyncio.Task]
         try:
             tasks = self._get_observation_tasks()
-            _, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+            done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+            for task in done:
+                with contextlib.suppress(asyncio.CancelledError):
+                    if exc := task.exception():
+                        self._receive_messages_exception = exc
         finally:
             self.state = WorkerState.NOT_RUNNING
 
@@ -170,7 +190,7 @@ class BaseWorker(Worker, ABC):
     async def stop(self, timeout: float) -> None:
         try:
             self.send(Exit())
-        except WorkerNotRunningError:
+        except BaseWorkerError:
             # No need to stop it then.
             return
 
@@ -292,3 +312,71 @@ class BaseWorker(Worker, ABC):
 
     async def get_static_file_index(self) -> dict[str, PackageFile]:
         return (await self.get_manifest()).static_files
+
+
+class LimitTimeUsageMixin(Worker, ABC):
+    """Implements a CPU and real time usage limit for a worker.
+
+    _limit_cpu_time_usage needs to be added to the return value of :meth:`BaseWorker._get_observation_tasks`.
+    The worker will be killed when the CPU time limit is exceeded or the worker took more than three times
+    the cpu limit in real time.
+    """
+
+    _real_time_limit_factor = 3
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._cur_cpu_time_limit: float = 0
+        self._request_started_cpu_time: float | None = None
+        self._request_started_time: float | None = None
+        self._request_started_event = asyncio.Event()
+
+    @abstractmethod
+    def _get_cpu_time(self) -> float:
+        """Get worker's current CPU time (user and system time).
+
+        Returns:
+            CPU time in seconds
+        """
+
+    def _set_time_limit(self, limit: float) -> None:
+        """Set a CPU and real time limit.
+
+        The real time limit is the CPU time limit * :meth:`LimitTimeUsageMixin._real_time_limit_factor`.
+
+        Args:
+            limit: CPU time limit in seconds
+        """
+        self._cur_cpu_time_limit = limit
+        self._request_started_cpu_time = self._get_cpu_time()
+        self._request_started_time = time.time()
+        self._request_started_event.set()
+
+    def _reset_time_limit(self) -> None:
+        self._cur_cpu_time_limit = 0
+        self._request_started_cpu_time = None
+        self._request_started_time = None
+        self._request_started_event.clear()
+
+    async def _limit_cpu_time_usage(self) -> None:
+        """Ensures that the worker will be killed when it is taking too much time. Executed as a task."""
+        while True:
+            await self._request_started_event.wait()
+
+            # CPU-time is always less or equal to real time (when single-threaded).
+            await asyncio.sleep(self._cur_cpu_time_limit)
+
+            # Check if the start time is still set. Probably the request was already processed or
+            # maybe another request started meanwhile.
+            while self._request_started_cpu_time is not None and self._request_started_time is not None:
+                remaining_cpu_time = self._request_started_cpu_time + self._cur_cpu_time_limit - self._get_cpu_time()
+                if remaining_cpu_time <= 0:
+                    raise WorkerCPUTimeLimitExceededError(self._cur_cpu_time_limit)
+
+                remaining_time = (
+                    self._request_started_time + (self._cur_cpu_time_limit * self._real_time_limit_factor) - time.time()
+                )
+                if remaining_time <= 0:
+                    raise WorkerRealTimeLimitExceededError(self._cur_cpu_time_limit * self._real_time_limit_factor)
+
+                await asyncio.sleep(max(min(remaining_cpu_time, remaining_time), 0.05))

--- a/questionpy_server/worker/impl/thread.py
+++ b/questionpy_server/worker/impl/thread.py
@@ -65,7 +65,7 @@ class ThreadWorker(BaseWorker):
     _worker_type = "thread"
 
     def __init__(self, package: PackageLocation, limits: WorkerResourceLimits | None) -> None:
-        super().__init__(package, limits)
+        super().__init__(package=package, limits=limits)
 
         self._pipe: DuplexPipe | None = None
 

--- a/questionpy_server/worker/pool.py
+++ b/questionpy_server/worker/pool.py
@@ -69,7 +69,6 @@ class WorkerPool:
             worker = None
             reserved_memory = False
             try:
-                # TODO: ???
                 limits = WorkerResourceLimits(max_memory=200 * MiB, max_cpu_time_seconds_per_call=10)
                 if self.max_memory < limits.max_memory:
                     msg = "The worker needs more memory than available."

--- a/questionpy_server/worker/runtime/manager.py
+++ b/questionpy_server/worker/runtime/manager.py
@@ -2,12 +2,10 @@
 #  The QuestionPy Server is free software released under terms of the MIT license. See LICENSE.md.
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
 import resource
-import signal
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
-from functools import wraps
-from typing import Any, NoReturn, cast, TypeAlias, TypeVar
+from typing import NoReturn, cast, TypeAlias, TypeVar
 
 from questionpy_common.api.qtype import QuestionTypeInterface
 from questionpy_common.environment import (
@@ -33,7 +31,6 @@ from questionpy_server.worker.runtime.messages import (
     StartAttempt,
     ViewAttempt,
     WorkerError,
-    WorkerTimeLimitExceededError,
 )
 from questionpy_server.worker.runtime.package import ImportablePackage, load_package
 
@@ -55,28 +52,6 @@ class EnvironmentImpl(Environment):
 
 M = TypeVar("M", bound=MessageToWorker)
 OnMessageCallback: TypeAlias = Callable[[M], MessageToServer]
-
-
-def timeout_after(seconds: float) -> Callable[[OnMessageCallback], OnMessageCallback]:
-    def decorator(function: OnMessageCallback) -> OnMessageCallback:
-        @wraps(function)
-        def wrapper(msg: M) -> MessageToServer:
-            def raise_time_limit_exceeded(*_: Any) -> NoReturn:
-                raise WorkerTimeLimitExceededError
-
-            # Create a timer that raises after the given amount of cpu time.
-            signal.signal(signal.SIGVTALRM, raise_time_limit_exceeded)
-            signal.setitimer(signal.ITIMER_VIRTUAL, seconds)
-
-            try:
-                return function(msg)
-            finally:
-                # Clear the timer.
-                signal.setitimer(signal.ITIMER_VIRTUAL, 0)
-
-        return wrapper
-
-    return decorator
 
 
 class WorkerManager:
@@ -113,10 +88,6 @@ class WorkerManager:
         if self._limits:
             # Limit memory usage.
             resource.setrlimit(resource.RLIMIT_AS, (self._limits.max_memory, self._limits.max_memory))
-            # Limit cpu time usage.
-            timeout = timeout_after(self._limits.max_cpu_time_seconds_per_call)
-            for message_id, callback in self._message_dispatch.items():
-                self._message_dispatch[message_id] = timeout(callback)
 
         self._connection.send_message(InitWorker.Response())
 

--- a/questionpy_server/worker/runtime/manager.py
+++ b/questionpy_server/worker/runtime/manager.py
@@ -5,7 +5,7 @@ import resource
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import NoReturn, cast, TypeAlias, TypeVar
+from typing import NoReturn, TypeAlias, TypeVar, cast
 
 from questionpy_common.api.qtype import QuestionTypeInterface
 from questionpy_common.environment import (

--- a/questionpy_server/worker/runtime/messages.py
+++ b/questionpy_server/worker/runtime/messages.py
@@ -202,7 +202,6 @@ class WorkerError(MessageToServer):
 
         UNKNOWN = auto()
         MEMORY_EXCEEDED = auto()
-        TIME_LIMIT_EXCEEDED = auto()
         QUESTION_STATE_INVALID = auto()
 
     message_id: ClassVar[MessageIds] = MessageIds.ERROR
@@ -218,8 +217,6 @@ class WorkerError(MessageToServer):
         """Get a WorkerError message from an exception."""
         if isinstance(error, MemoryError):
             error_type = WorkerError.ErrorType.MEMORY_EXCEEDED
-        elif isinstance(error, WorkerTimeLimitExceededError):
-            error_type = WorkerError.ErrorType.TIME_LIMIT_EXCEEDED
         elif isinstance(error, InvalidQuestionStateError):
             error_type = WorkerError.ErrorType.QUESTION_STATE_INVALID
         else:
@@ -242,8 +239,6 @@ class WorkerError(MessageToServer):
         error: Exception
         if self.type == WorkerError.ErrorType.MEMORY_EXCEEDED:
             error = WorkerMemoryLimitExceededError(self.message)
-        elif self.type == WorkerError.ErrorType.TIME_LIMIT_EXCEEDED:
-            error = WorkerTimeLimitExceededError(self.message)
         elif self.type == WorkerError.ErrorType.QUESTION_STATE_INVALID:
             error = InvalidQuestionStateError(self.message)
         else:
@@ -275,10 +270,6 @@ class InvalidMessageIdError(Exception):
 
 
 class WorkerMemoryLimitExceededError(Exception):
-    pass
-
-
-class WorkerTimeLimitExceededError(Exception):
     pass
 
 

--- a/questionpy_server/worker/runtime/messages.py
+++ b/questionpy_server/worker/runtime/messages.py
@@ -202,6 +202,7 @@ class WorkerError(MessageToServer):
 
         UNKNOWN = auto()
         MEMORY_EXCEEDED = auto()
+        TIME_LIMIT_EXCEEDED = auto()
         QUESTION_STATE_INVALID = auto()
 
     message_id: ClassVar[MessageIds] = MessageIds.ERROR
@@ -217,6 +218,8 @@ class WorkerError(MessageToServer):
         """Get a WorkerError message from an exception."""
         if isinstance(error, MemoryError):
             error_type = WorkerError.ErrorType.MEMORY_EXCEEDED
+        elif isinstance(error, WorkerTimeLimitExceededError):
+            error_type = WorkerError.ErrorType.TIME_LIMIT_EXCEEDED
         elif isinstance(error, InvalidQuestionStateError):
             error_type = WorkerError.ErrorType.QUESTION_STATE_INVALID
         else:
@@ -239,6 +242,8 @@ class WorkerError(MessageToServer):
         error: Exception
         if self.type == WorkerError.ErrorType.MEMORY_EXCEEDED:
             error = WorkerMemoryLimitExceededError(self.message)
+        elif self.type == WorkerError.ErrorType.TIME_LIMIT_EXCEEDED:
+            error = WorkerTimeLimitExceededError(self.message)
         elif self.type == WorkerError.ErrorType.QUESTION_STATE_INVALID:
             error = InvalidQuestionStateError(self.message)
         else:
@@ -270,6 +275,10 @@ class InvalidMessageIdError(Exception):
 
 
 class WorkerMemoryLimitExceededError(Exception):
+    pass
+
+
+class WorkerTimeLimitExceededError(Exception):
     pass
 
 

--- a/questionpy_server/worker/runtime/messages.py
+++ b/questionpy_server/worker/runtime/messages.py
@@ -269,9 +269,13 @@ class InvalidMessageIdError(Exception):
         super().__init__(f"Received unknown message with id {message_id} and length {length}.")
 
 
-class WorkerMemoryLimitExceededError(Exception):
+class BaseWorkerError(Exception):
     pass
 
 
-class WorkerUnknownError(Exception):
+class WorkerMemoryLimitExceededError(BaseWorkerError):
+    pass
+
+
+class WorkerUnknownError(BaseWorkerError):
     pass

--- a/tests/questionpy_server/worker/impl/test_subprocess.py
+++ b/tests/questionpy_server/worker/impl/test_subprocess.py
@@ -1,14 +1,20 @@
 #  This file is part of the QuestionPy Server. (https://questionpy.org)
 #  The QuestionPy Server is free software released under terms of the MIT license. See LICENSE.md.
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+import math
 import resource
+from unittest.mock import patch
 
 import psutil
 import pytest
 
 from questionpy_common.constants import MiB
+from questionpy_common.environment import WorkerResourceLimits
 from questionpy_server import WorkerPool
+from questionpy_server.worker.impl import Worker
 from questionpy_server.worker.impl.subprocess import SubprocessWorker
+from questionpy_server.worker.runtime.messages import WorkerTimeLimitExceededError
+from questionpy_server.worker.runtime.package_location import PackageLocation
 from tests.conftest import PACKAGE
 
 
@@ -26,3 +32,14 @@ async def test_should_apply_limits(pool: WorkerPool) -> None:
         soft, hard = psutil_process.rlimit(resource.RLIMIT_AS)
 
     assert soft == hard == 200 * MiB
+
+
+async def test_should_raise_timout_error(pool: WorkerPool) -> None:
+    def worker_init(self: Worker, package: PackageLocation, _: WorkerResourceLimits | None) -> None:
+        self.package = package
+        # Set the cpu time limit to a small float greater than zero.
+        self.limits = WorkerResourceLimits(200 * MiB, math.ulp(0))
+
+    with pytest.raises(WorkerTimeLimitExceededError), patch.object(Worker, "__init__", worker_init):
+        async with pool.get_worker(PACKAGE, 1, 1):
+            pass

--- a/tests/questionpy_server/worker/impl/test_subprocess.py
+++ b/tests/questionpy_server/worker/impl/test_subprocess.py
@@ -11,9 +11,9 @@ import pytest
 from questionpy_common.constants import MiB
 from questionpy_common.environment import WorkerResourceLimits
 from questionpy_server import WorkerPool
-from questionpy_server.worker.impl import Worker
+from questionpy_server.worker import Worker
+from questionpy_server.worker.exception import WorkerCPUTimeLimitExceededError
 from questionpy_server.worker.impl.subprocess import SubprocessWorker
-from questionpy_server.worker.runtime.messages import WorkerTimeLimitExceededError
 from questionpy_server.worker.runtime.package_location import PackageLocation
 from tests.conftest import PACKAGE
 
@@ -40,6 +40,6 @@ async def test_should_raise_timout_error(pool: WorkerPool) -> None:
         # Set the cpu time limit to a small float greater than zero.
         self.limits = WorkerResourceLimits(200 * MiB, math.ulp(0))
 
-    with pytest.raises(WorkerTimeLimitExceededError), patch.object(Worker, "__init__", worker_init):
+    with pytest.raises(WorkerCPUTimeLimitExceededError), patch.object(Worker, "__init__", worker_init):
         async with pool.get_worker(PACKAGE, 1, 1):
             pass

--- a/tests/questionpy_server/worker/impl/test_subprocess.py
+++ b/tests/questionpy_server/worker/impl/test_subprocess.py
@@ -1,21 +1,27 @@
 #  This file is part of the QuestionPy Server. (https://questionpy.org)
 #  The QuestionPy Server is free software released under terms of the MIT license. See LICENSE.md.
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
-import math
 import resource
+from collections.abc import Iterator
+from contextlib import contextmanager
+from time import process_time, sleep, time
 from unittest.mock import patch
 
 import psutil
 import pytest
 
 from questionpy_common.constants import MiB
-from questionpy_common.environment import WorkerResourceLimits
 from questionpy_server import WorkerPool
-from questionpy_server.worker import Worker
-from questionpy_server.worker.exception import WorkerCPUTimeLimitExceededError
+from questionpy_server.worker.exception import (
+    WorkerCPUTimeLimitExceededError,
+    WorkerRealTimeLimitExceededError,
+    WorkerStartError,
+)
+from questionpy_server.worker.impl._base import BaseWorker, LimitTimeUsageMixin
 from questionpy_server.worker.impl.subprocess import SubprocessWorker
-from questionpy_server.worker.runtime.package_location import PackageLocation
+from questionpy_server.worker.runtime.manager import WorkerManager
 from tests.conftest import PACKAGE
+from tests.questionpy_server.worker.impl.conftest import patch_worker_pool
 
 
 @pytest.fixture
@@ -34,12 +40,49 @@ async def test_should_apply_limits(pool: WorkerPool) -> None:
     assert soft == hard == 200 * MiB
 
 
-async def test_should_raise_timout_error(pool: WorkerPool) -> None:
-    def worker_init(self: Worker, package: PackageLocation, _: WorkerResourceLimits | None) -> None:
-        self.package = package
-        # Set the cpu time limit to a small float greater than zero.
-        self.limits = WorkerResourceLimits(200 * MiB, math.ulp(0))
-
-    with pytest.raises(WorkerCPUTimeLimitExceededError), patch.object(Worker, "__init__", worker_init):
-        async with pool.get_worker(PACKAGE, 1, 1):
+@contextmanager
+def _make_get_manifest_busy_wait() -> Iterator[None]:
+    def busy_wait(self: WorkerManager) -> None:
+        wait_until = process_time() + 10
+        while wait_until > process_time():
             pass
+
+    with patch.object(WorkerManager, "bootstrap", busy_wait):
+        yield
+
+
+async def test_should_raise_cpu_timout_error(pool: WorkerPool) -> None:
+    with patch_worker_pool(pool, _make_get_manifest_busy_wait):
+        start_time = time()
+        # Change the timeout for faster testing.
+        with pytest.raises(WorkerStartError) as exc_info, patch.object(BaseWorker, "_init_worker_timeout", 0.05):
+            async with pool.get_worker(PACKAGE, 1, 1):
+                pass
+        assert isinstance(exc_info.value.__cause__, WorkerCPUTimeLimitExceededError)
+        assert 0.05 < (time() - start_time) < 0.5
+
+
+@contextmanager
+def _make_get_manifest_sleep() -> Iterator[None]:
+    def _sleep(self: WorkerManager) -> None:
+        sleep(10)
+
+    with patch.object(WorkerManager, "bootstrap", _sleep):
+        yield
+
+
+async def test_should_raise_real_timout_error(pool: WorkerPool) -> None:
+    with patch_worker_pool(pool, _make_get_manifest_sleep):
+        # The timeout should not be too short, because the Python interpreter also needs some time to start up, which
+        # is accounted for the init worker step. Otherwise, a WorkerCPUTimeLimitExceededError is raised.
+        start_time = time()
+        with (
+            pytest.raises(WorkerStartError) as exc_info,
+            # Change the timeout and factor for faster testing.
+            patch.object(BaseWorker, "_init_worker_timeout", 0.6),
+            patch.object(LimitTimeUsageMixin, "_real_time_limit_factor", 1.0),
+        ):
+            async with pool.get_worker(PACKAGE, 1, 1) as worker:
+                await worker.get_manifest()
+        assert isinstance(exc_info.value.__cause__, WorkerRealTimeLimitExceededError)
+        assert 0.6 < (time() - start_time) < 2.0


### PR DESCRIPTION
Es wird ein `WorkerCPUTimeLimitExceededError` für den Worker-Task gesetzt, sobal dieser mehr als CPU-Zeit beansprucht, als vorher `WorkerResourceLimits.max_cpu_time_seconds_per_call`.