### PR TITLE
feat: reusable workers

### DIFF
--- a/questionpy_server/settings.py
+++ b/questionpy_server/settings.py
@@ -107,7 +107,7 @@ class WorkerSettings(BaseModel):
 
 
 class PackageCacheSettings(BaseModel):
-    size: ByteSize = ByteSize(5 * MiB)
+    size: ByteSize = ByteSize(100 * MiB)
     directory: DirectoryPath = Path("cache/packages").resolve()
 
     @field_validator("directory")

--- a/questionpy_server/web/_routes/_status.py
+++ b/questionpy_server/web/_routes/_status.py
@@ -21,8 +21,8 @@ async def get_server_status(request: web.Request) -> web.Response:
         allow_lms_packages=qpyserver.settings.webservice.allow_lms_packages,
         max_package_size=qpyserver.settings.webservice.max_package_size,
         usage=Usage(
-            requests_in_process=await qpyserver.worker_pool.get_requests_in_process(),
-            requests_in_queue=await qpyserver.worker_pool.get_requests_in_queue(),
+            requests_in_process=qpyserver.worker_pool.get_workers_in_use_count(),
+            requests_in_queue=qpyserver.worker_pool.get_pending_worker_request_count(),
         ),
     )
     return pydantic_json_response(data=status, status=200)

--- a/questionpy_server/web/app.py
+++ b/questionpy_server/web/app.py
@@ -48,6 +48,7 @@ class QPyServer:
 
         self.web_app.on_startup.append(self._start_package_collection)
         self.web_app.on_shutdown.append(self._stop_package_collection)
+        self.web_app.on_shutdown.append(self._stop_idle_workers)
 
     async def _start_package_collection(self, _app: web.Application) -> None:
         # The server will not wait until all package collectors are started. This is done in the background.
@@ -57,6 +58,9 @@ class QPyServer:
     async def _stop_package_collection(self, _app: web.Application) -> None:
         # Wait until all package collectors are stopped appropriately.
         await self.package_collection.stop()
+
+    async def _stop_idle_workers(self, _app: web.Application) -> None:
+        await self.worker_pool.stop_idle_workers()
 
     def start_server(self) -> None:
         port = self.settings.webservice.listen_port

--- a/questionpy_server/worker/impl/_base.py
+++ b/questionpy_server/worker/impl/_base.py
@@ -111,6 +111,7 @@ class BaseWorker(Worker, ABC):
                 LoadedPackage(namespace=loaded.nssn.namespace, short_name=loaded.nssn.short_name, hash=packagehash)
             )
         except BaseWorkerError as e:
+            await self.stop(3)
             msg = "Worker has exited before or during initialization."
             raise WorkerStartError(msg, temporary=e.temporary) from e
 
@@ -128,9 +129,12 @@ class BaseWorker(Worker, ABC):
         self.state = WorkerState.SERVER_AWAITS_RESPONSE
         try:
             result = await fut
+        except WorkerNotRunningError:
+            self.state = WorkerState.NOT_RUNNING
+            raise
         finally:
-            # We also want to reset the state upon error.
-            self.state = WorkerState.IDLE
+            if self.state != WorkerState.NOT_RUNNING:
+                self.state = WorkerState.IDLE
         return result
 
     async def _receive_messages(self) -> None:
@@ -174,7 +178,7 @@ class BaseWorker(Worker, ABC):
 
     async def _observe(self) -> None:
         """Observes the tasks returned by _get_observation_tasks."""
-        pending: set[asyncio.Task]
+        pending: set[asyncio.Task] = set()
         try:
             tasks = self._get_observation_tasks()
             done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)

--- a/questionpy_server/worker/impl/thread.py
+++ b/questionpy_server/worker/impl/thread.py
@@ -45,6 +45,12 @@ class _WorkerThread(threading.Thread):
         try:
             manager.bootstrap()
             manager.loop()
+        except EOFError:
+            # TODO: Because of the asyncio.CancelledError caused by aiohttp when exiting the program, the DuplexPipe
+            #  gets closed in the finally-block of ThreadWorker._run_and_wait. Therefore,
+            #  WorkerToServerConnection.receive_message throws an EOFError. It would be nice to be able to stop an idle
+            #  worker with the Exit-message.
+            pass
         finally:
             # Since asyncio.Event is not threadsafe, we schedule setting it in the main thread instead.
             self._loop.call_soon_threadsafe(self._end_event.set)
@@ -67,7 +73,7 @@ class _WorkerThread(threading.Thread):
 
 
 class ThreadWorker(BaseWorker):
-    """Worker implementation using a thread withing the server process for simpler debugging of package code."""
+    """Worker implementation using a thread within the server process for simpler debugging of package code."""
 
     _worker_type = "thread"
 

--- a/questionpy_server/worker/pool.py
+++ b/questionpy_server/worker/pool.py
@@ -1,18 +1,38 @@
 #  This file is part of the QuestionPy Server. (https://questionpy.org)
 #  The QuestionPy Server is free software released under terms of the MIT license. See LICENSE.md.
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
-
-from asyncio import Condition, Semaphore
+from asyncio import Condition, Lock, Semaphore
+from collections import defaultdict, deque
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from typing import NamedTuple
 
 from questionpy_common.constants import MiB
 from questionpy_common.environment import WorkerResourceLimits
+from questionpy_common.error import QPyBaseError
 from questionpy_server.worker.impl.subprocess import SubprocessWorker
 from questionpy_server.worker.runtime.package_location import PackageLocation
 
-from . import Worker
+from . import Worker, WorkerState
 from .exception import WorkerStartError
+from .impl.thread import ThreadWorker
+
+
+class _WorkerPoolMemoryError(QPyBaseError):
+    """Raised when the worker pool cannot free enough memory."""
+
+    def __init__(self) -> None:
+        super().__init__("Cannot free the required amount of memory. This is likely a bug.")
+
+
+def _memory_limit_or_zero(limits: WorkerResourceLimits | None) -> int:
+    return limits.max_memory if limits else 0
+
+
+class _IdleWorkersIdentifier(NamedTuple):
+    package: PackageLocation
+    lms: int
+    context: int | None
 
 
 class WorkerPool:
@@ -29,45 +49,49 @@ class WorkerPool:
 
         self._worker_type = worker_type
 
-        self._semaphore: Semaphore | None = None
-        self._condition: Condition | None = None
+        self._lock: Lock = Lock()
+        self._semaphore: Semaphore = Semaphore(self.max_workers)
+        self._condition: Condition = Condition()
 
-        self._running_workers: int = 0
-        self._requests: int = 0
+        self._idle_workers: dict[_IdleWorkersIdentifier, deque[Worker]] = defaultdict(deque)
+        """Maps a package to a deque of workers that are currently idle and have that package loaded. The first worker
+        in the deque is the most recently used one."""
+        self._oldest_idle_workers: deque[tuple[Worker, _IdleWorkersIdentifier]] = deque()
+        """A deque of workers that are currently idle and have a package loaded. The first worker in the deque is the
+        most recently used one."""
 
-        self._total_memory = 0
+        self._workers_requested: int = 0
+        self._workers_in_use: int = 0
 
-    def memory_available(self, size: int) -> bool:
-        return self._total_memory + size <= self.max_memory
+        self._memory_in_use = 0
+        self._memory_idle = 0
+
+    def _memory_available(self, required_memory: int) -> bool:
+        """Checks whether the required memory to start or reuse a worker is available.
+
+        The total memory of idle workers is not considered.
+        """
+        return self.max_memory - self._memory_in_use >= required_memory
 
     @asynccontextmanager
-    async def get_worker(self, package: PackageLocation, _lms: int, _context: int | None) -> AsyncIterator[Worker]:
+    async def get_worker(self, package: PackageLocation, lms: int, context: int | None) -> AsyncIterator[Worker]:
         """Get a (new) worker executing a QuestionPy package.
 
         A context manager is used to ensure that a worker is always given back to the pool.
 
         Args:
             package: path to QuestionPy package
-            _lms: id of the LMS
-            _context: context id within the lms
+            lms: id of the LMS
+            context: context id within the lms
 
         Returns:
             A worker
         """
-        if not self._semaphore:
-            self._semaphore = Semaphore(self.max_workers)
-
-        if not self._condition:
-            self._condition = Condition()
-
-        self._requests += 1
+        self._workers_requested += 1
 
         # Limit the amount of running workers.
         async with self._semaphore:
-            self._running_workers += 1
-
             worker = None
-            reserved_memory = False
             try:
                 limits = WorkerResourceLimits(max_memory=200 * MiB, max_cpu_time_seconds_per_call=10)
                 if self.max_memory < limits.max_memory:
@@ -75,41 +99,122 @@ class WorkerPool:
                     raise WorkerStartError(msg)
 
                 # Wait until there is enough memory available.
-                async with self._condition:
-                    await self._condition.wait_for(lambda: self.memory_available(limits.max_memory))
-                    # Reserve memory for the new worker.
-                    self._total_memory += limits.max_memory
-                    reserved_memory = True
-
-                worker = self._worker_type(package, limits)
-                await worker.start()
+                # We need the additional lock, since `Condition.wait_for`/`Condition.notify` in comparison to
+                # `Lock.acquire` is not explicitly documented as fair. This ensures that no starvation occurs.
+                async with self._lock, self._condition:
+                    await self._condition.wait_for(lambda: self._memory_available(limits.max_memory))
+                    worker = await self._create_or_reuse_worker(package, lms, context, limits)
+                    self._workers_in_use += 1
 
                 yield worker
             finally:
                 if worker:
-                    await worker.stop(10)
-
-                if reserved_memory:
-                    # Free reserved memory and notify waiters.
-                    self._total_memory -= limits.max_memory
                     async with self._condition:
-                        self._condition.notify_all()
+                        await self._handle_idle_worker(package, lms, context, worker)
+                        self._condition.notify()
+                        self._workers_in_use -= 1
 
-                self._running_workers -= 1
-                self._requests -= 1
+                self._workers_requested -= 1
 
-    async def get_requests_in_process(self) -> int:
-        """Get the number of workers currently running.
-
-        Returns:
-            int: The count of workers currently running.
-        """
-        return self._running_workers
-
-    async def get_requests_in_queue(self) -> int:
-        """Get the number of pending requests.
+    async def _stop_oldest_idle_worker(self) -> int | None:
+        """Stops the oldest idle worker.
 
         Returns:
-            int: The count of pending requests.
+            The freed memory or None if there are no more idle workers to stop.
         """
-        return self._requests - self._running_workers
+        if not self._oldest_idle_workers:
+            return None
+
+        # Get the oldest worker and remove it.
+        worker, identifier = self._oldest_idle_workers.pop()
+        self._idle_workers[identifier].remove(worker)
+        if not self._idle_workers[identifier]:
+            # There are no more available workers with this package.
+            del self._idle_workers[identifier]
+
+        # Stop the worker and free the memory.
+        await worker.stop(10)
+
+        max_memory = _memory_limit_or_zero(worker.limits)
+        self._memory_idle -= max_memory
+        return max_memory
+
+    async def _free_memory(self, required_memory: int) -> None:
+        """Stops idle workers until the required amount of memory is available."""
+        available_memory = self.max_memory - self._memory_in_use - self._memory_idle
+        if available_memory >= required_memory:
+            # As there is more memory available than required, we do not need to stop any idle workers.
+            return
+
+        # Stop only as many workers as needed.
+        required_memory -= available_memory
+        while required_memory > 0:
+            freed_memory = await self._stop_oldest_idle_worker()
+            if freed_memory is None:
+                break
+            required_memory -= freed_memory
+
+        if required_memory > 0:
+            raise _WorkerPoolMemoryError
+
+    async def _create_or_reuse_worker(
+        self, package: PackageLocation, lms: int, context: int | None, limits: WorkerResourceLimits
+    ) -> Worker:
+        """If possible, get an idle worker or create a new one."""
+        identifier = _IdleWorkersIdentifier(package, lms, context)
+        if identifier in self._idle_workers:
+            # There is an idle worker with this package loaded - reuse the most recent one.
+            worker = self._idle_workers[identifier].popleft()
+            if not self._idle_workers[identifier]:
+                # There are no more available workers with this package.
+                del self._idle_workers[identifier]
+            self._oldest_idle_workers.remove((worker, identifier))
+
+            self._memory_idle -= _memory_limit_or_zero(worker.limits)
+        else:
+            # We need to create a new worker - free as much memory as needed to start the worker.
+            await self._free_memory(limits.max_memory)
+            worker = self._worker_type(package, limits)
+            await worker.start()
+
+        # Reserve the memory.
+        self._memory_in_use += limits.max_memory if self._worker_type is not ThreadWorker else 0
+
+        return worker
+
+    async def _handle_idle_worker(
+        self, package: PackageLocation, lms: int, context: int | None, worker: Worker
+    ) -> None:
+        """Adds a worker to the pool of reusable workers."""
+        # Free reserved memory.
+        self._memory_in_use -= _memory_limit_or_zero(worker.limits)
+
+        # Check if the worker is idling.
+        if worker.state == WorkerState.IDLE:
+            # Free as much memory as need to store the idle worker.
+            required_memory = _memory_limit_or_zero(worker.limits)
+            await self._free_memory(required_memory)
+
+            # Add the worker.
+            identifier = _IdleWorkersIdentifier(package, lms, context)
+            self._idle_workers[identifier].appendleft(worker)
+            self._oldest_idle_workers.appendleft((worker, identifier))
+
+            self._memory_idle += _memory_limit_or_zero(worker.limits)
+        else:
+            # We cannot reuse this worker as it is not idling.
+            await worker.stop(10)
+
+    async def stop_idle_workers(self) -> None:
+        """Stops all idle workers gracefully."""
+        async with self._condition:
+            while await self._stop_oldest_idle_worker() is not None:
+                continue
+
+    def get_workers_in_use_count(self) -> int:
+        """Get the number of workers currently running but not idle."""
+        return self._workers_in_use
+
+    def get_pending_worker_request_count(self) -> int:
+        """Get the number of pending worker requests."""
+        return self._workers_requested - self._workers_in_use

--- a/questionpy_server/worker/runtime/package_location.py
+++ b/questionpy_server/worker/runtime/package_location.py
@@ -17,11 +17,14 @@ class ZipPackageLocation:
     hash: str
     kind: Literal["zip"] = field(default="zip", init=False)
 
+    def __hash__(self) -> int:
+        return hash(self.hash)
+
     def __str__(self) -> str:
         return f"{self.path} (sha256:{self.hash})"
 
 
-@dataclass
+@dataclass(unsafe_hash=True)
 class DirPackageLocation:
     """A package's dist directory to be loaded directly."""
 
@@ -33,7 +36,7 @@ class DirPackageLocation:
         return str(self.path)
 
 
-@dataclass
+@dataclass(unsafe_hash=True)
 class FunctionPackageLocation:
     """A package consisting only of its init function. Intended mostly for unit tests.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@
 
 import mimetypes
 import tempfile
-from collections.abc import Iterable
+from collections.abc import AsyncGenerator, Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from zipfile import ZipFile
@@ -34,7 +34,7 @@ from questionpy_server.worker.pool import WorkerPool
 from questionpy_server.worker.runtime.package_location import DirPackageLocation, ZipPackageLocation
 
 
-@dataclass
+@dataclass(unsafe_hash=True)
 class TestZipPackage(ZipPackageLocation):
     __test__ = False
 
@@ -45,7 +45,7 @@ class TestZipPackage(ZipPackageLocation):
             self.manifest = ComparableManifest.model_validate_json(package.read(f"{DIST_DIR}/{MANIFEST_FILENAME}"))
 
 
-@dataclass
+@dataclass(unsafe_hash=True)
 class TestDirPackage(DirPackageLocation):
     __test__ = False
 
@@ -146,5 +146,9 @@ def package_factory(tmp_path_factory: pytest.TempPathFactory) -> TestPackageFact
 
 
 @pytest.fixture(params=(SubprocessWorker, ThreadWorker))
-def worker_pool(request: pytest.FixtureRequest) -> WorkerPool:
-    return WorkerPool(1, 512 * MiB, worker_type=request.param)
+async def worker_pool(request: pytest.FixtureRequest) -> AsyncGenerator[WorkerPool]:
+    pool = WorkerPool(1, 512 * MiB, worker_type=request.param)
+    try:
+        yield pool
+    finally:
+        await pool.stop_idle_workers()

--- a/tests/questionpy_server/collector/test_indexer.py
+++ b/tests/questionpy_server/collector/test_indexer.py
@@ -8,7 +8,6 @@ from unittest.mock import patch
 
 import pytest
 
-from questionpy_common.constants import MiB
 from questionpy_server import WorkerPool
 from questionpy_server.collector.abc import BaseCollector
 from questionpy_server.collector.indexer import Indexer
@@ -23,9 +22,11 @@ from tests.conftest import PACKAGE
 @pytest.mark.parametrize("kind", [PACKAGE.path, PACKAGE.manifest])
 @patch("questionpy_server.collector.lms_collector.LMSCollector", spec=LMSCollector)
 async def test_register_package_with_path_and_manifest(
-    collector: LMSCollector, kind: Path | ComparableManifest
+    collector: LMSCollector,
+    kind: Path | ComparableManifest,
+    worker_pool: WorkerPool,
 ) -> None:
-    indexer = Indexer(WorkerPool(1, 200 * MiB))
+    indexer = Indexer(worker_pool)
     await indexer.register_package(PACKAGE.hash, kind, collector)
 
     # Package is accessible by hash.
@@ -36,8 +37,8 @@ async def test_register_package_with_path_and_manifest(
 
 
 @patch("questionpy_server.collector.lms_collector.LMSCollector", spec=LMSCollector)
-async def test_register_package_from_lms(collector: LMSCollector) -> None:
-    indexer = Indexer(WorkerPool(1, 200 * MiB))
+async def test_register_package_from_lms(collector: LMSCollector, worker_pool: WorkerPool) -> None:
+    indexer = Indexer(worker_pool)
     await indexer.register_package(PACKAGE.hash, PACKAGE.manifest, collector)
 
     # Package is not accessible by identifier and version.
@@ -54,11 +55,13 @@ async def test_register_package_from_lms(collector: LMSCollector) -> None:
 
 
 @pytest.mark.parametrize("collector", [LocalCollector, RepoCollector])
-async def test_register_package_from_local_and_repo_collector(collector: BaseCollector) -> None:
+async def test_register_package_from_local_and_repo_collector(
+    collector: BaseCollector, worker_pool: WorkerPool
+) -> None:
     # Create mock.
     collector = patch(collector.__module__, spec=collector).start()
 
-    indexer = Indexer(WorkerPool(1, 200 * MiB))
+    indexer = Indexer(worker_pool)
     await indexer.register_package(PACKAGE.hash, PACKAGE.manifest, collector)
 
     # Package is accessible by hash.
@@ -83,8 +86,8 @@ async def test_register_package_from_local_and_repo_collector(collector: BaseCol
     assert next(iter(packages)).manifest.model_dump().items() <= package.manifest.model_dump().items()
 
 
-async def test_register_package_with_same_hash_as_existing_package() -> None:
-    indexer = Indexer(WorkerPool(1, 200 * MiB))
+async def test_register_package_with_same_hash_as_existing_package(worker_pool: WorkerPool) -> None:
+    indexer = Indexer(worker_pool)
 
     # Register package from local collector.
     local_collector = patch(LocalCollector.__module__, spec=LocalCollector).start()
@@ -114,12 +117,14 @@ async def test_register_package_with_same_hash_as_existing_package() -> None:
     assert packages[0].manifest.model_dump().items() <= package.manifest.model_dump().items()
 
 
-async def test_register_two_packages_with_same_manifest_but_different_hashes(caplog: pytest.LogCaptureFixture) -> None:
+async def test_register_two_packages_with_same_manifest_but_different_hashes(
+    caplog: pytest.LogCaptureFixture, worker_pool: WorkerPool
+) -> None:
     # Create mock.
     collector = patch(LocalCollector.__module__, spec=LocalCollector).start()
 
     # Register a package.
-    indexer = Indexer(WorkerPool(1, 200 * MiB))
+    indexer = Indexer(worker_pool)
     await indexer.register_package(PACKAGE.hash, PACKAGE.manifest, collector)
 
     with caplog.at_level(logging.WARNING):
@@ -133,8 +138,8 @@ async def test_register_two_packages_with_same_manifest_but_different_hashes(cap
     assert caplog.record_tuples == [("questionpy-server:indexer", logging.WARNING, message)]
 
 
-async def test_unregister_package_with_lms_source() -> None:
-    indexer = Indexer(WorkerPool(1, 200 * MiB))
+async def test_unregister_package_with_lms_source(worker_pool: WorkerPool) -> None:
+    indexer = Indexer(worker_pool)
     collector = patch(LMSCollector.__module__, spec=LMSCollector).start()
     await indexer.register_package(PACKAGE.hash, PACKAGE.manifest, collector)
 
@@ -146,8 +151,8 @@ async def test_unregister_package_with_lms_source() -> None:
 
 
 @pytest.mark.parametrize("collector", [LocalCollector, RepoCollector])
-async def test_unregister_package_with_local_and_repo_source(collector: BaseCollector) -> None:
-    indexer = Indexer(WorkerPool(1, 200 * MiB))
+async def test_unregister_package_with_local_and_repo_source(collector: BaseCollector, worker_pool: WorkerPool) -> None:
+    indexer = Indexer(worker_pool)
     collector = patch(collector.__module__, spec=collector).start()
     await indexer.register_package(PACKAGE.hash, PACKAGE.manifest, collector)
 
@@ -166,8 +171,8 @@ async def test_unregister_package_with_local_and_repo_source(collector: BaseColl
     assert len(packages) == 0
 
 
-async def test_unregister_package_with_multiple_sources() -> None:
-    indexer = Indexer(WorkerPool(1, 200 * MiB))
+async def test_unregister_package_with_multiple_sources(worker_pool: WorkerPool) -> None:
+    indexer = Indexer(worker_pool)
 
     # Register package from local, repo, and LMS collector.
     lms_collector = patch(LMSCollector.__module__, spec=LMSCollector).start()

--- a/tests/questionpy_server/collector/test_lms_collector.py
+++ b/tests/questionpy_server/collector/test_lms_collector.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import pytest
 from _pytest.tmpdir import TempPathFactory
 
-from questionpy_common.constants import KiB, MiB
+from questionpy_common.constants import KiB
 from questionpy_server import WorkerPool
 from questionpy_server.cache import FileLimitLRU
 from questionpy_server.collector.indexer import Indexer
@@ -18,18 +18,13 @@ from questionpy_server.worker.runtime.messages import BaseWorkerError
 from tests.conftest import PACKAGE
 
 
-def create_lms_collector(tmp_path_factory: TempPathFactory) -> tuple[LMSCollector, FileLimitLRU]:
-    """Create a local collector and return it and the cache it is using.
-
-    Args:
-        tmp_path_factory (TempPathFactory): Factory for temporary directories.
-
-    Returns:
-        Local collector and cache.
-    """
+def create_lms_collector(
+    tmp_path_factory: TempPathFactory, worker_pool: WorkerPool
+) -> tuple[LMSCollector, FileLimitLRU]:
+    """Creates and returns a local collector along with the cache it is using."""
     path = tmp_path_factory.mktemp("qpy")
     cache = FileLimitLRU(path, 100 * KiB, extension=".qpy")
-    indexer = Indexer(WorkerPool(1, 200 * MiB))
+    indexer = Indexer(worker_pool)
     return LMSCollector(cache, indexer), cache
 
 
@@ -54,8 +49,8 @@ async def test_package_in_cache_before_init(tmp_path_factory: TempPathFactory) -
     assert path is not None
 
 
-async def test_put(tmp_path_factory: TempPathFactory) -> None:
-    lms_collector, cache = create_lms_collector(tmp_path_factory)
+async def test_put(tmp_path_factory: TempPathFactory, worker_pool: WorkerPool) -> None:
+    lms_collector, cache = create_lms_collector(tmp_path_factory, worker_pool)
 
     package_bytes = PACKAGE.path.read_bytes()
     hash_container = HashContainer(package_bytes, PACKAGE.hash)
@@ -73,8 +68,8 @@ async def test_put(tmp_path_factory: TempPathFactory) -> None:
     assert package_2 is package
 
 
-async def test_get_non_existing_file(tmp_path_factory: TempPathFactory) -> None:
-    lms_collector, cache = create_lms_collector(tmp_path_factory)
+async def test_get_non_existing_file(tmp_path_factory: TempPathFactory, worker_pool: WorkerPool) -> None:
+    lms_collector, cache = create_lms_collector(tmp_path_factory, worker_pool)
 
     package_bytes = PACKAGE.path.read_bytes()
     hash_container = HashContainer(package_bytes, PACKAGE.hash)
@@ -89,8 +84,10 @@ async def test_get_non_existing_file(tmp_path_factory: TempPathFactory) -> None:
         await lms_collector.get_path(package)
 
 
-async def test_lms_collector_is_resilient_to_faulty_packages_on_start(tmp_path_factory: TempPathFactory) -> None:
-    lms_collector, cache = create_lms_collector(tmp_path_factory)
+async def test_lms_collector_is_resilient_to_faulty_packages_on_start(
+    tmp_path_factory: TempPathFactory, worker_pool: WorkerPool
+) -> None:
+    lms_collector, cache = create_lms_collector(tmp_path_factory, worker_pool)
 
     invalid_package = b"this is a invalid package"
     file = cache.directory / f"{calculate_hash(invalid_package)}.qpy"
@@ -108,8 +105,10 @@ async def test_lms_collector_is_resilient_to_faulty_packages_on_start(tmp_path_f
         assert cache.get(hash_container.hash) == await lms_collector.get_path(package)
 
 
-async def test_lms_collector_raises_error_on_faulty_package_on_put(tmp_path_factory: TempPathFactory) -> None:
-    lms_collector, cache = create_lms_collector(tmp_path_factory)
+async def test_lms_collector_raises_error_on_faulty_package_on_put(
+    tmp_path_factory: TempPathFactory, worker_pool: WorkerPool
+) -> None:
+    lms_collector, cache = create_lms_collector(tmp_path_factory, worker_pool)
 
     invalid_package = b"this is a invalid package"
     hash_container = HashContainer(invalid_package, calculate_hash(invalid_package))

--- a/tests/questionpy_server/collector/test_local_collector.py
+++ b/tests/questionpy_server/collector/test_local_collector.py
@@ -14,7 +14,6 @@ from unittest.mock import patch
 import pytest
 from _pytest.tmpdir import TempPathFactory
 
-from questionpy_common.constants import MiB
 from questionpy_server import WorkerPool
 from questionpy_server.collector.indexer import Indexer
 from questionpy_server.collector.local_collector import LocalCollector
@@ -23,17 +22,10 @@ from questionpy_server.package import Package
 from tests.conftest import PACKAGE, PACKAGE_2
 
 
-def create_local_collector(tmp_path_factory: TempPathFactory) -> tuple[LocalCollector, Path]:
-    """Create a local collector and return it and the directory it is using.
-
-    Args:
-        tmp_path_factory (TempPathFactory): Factory for temporary directories.
-
-    Returns:
-        Local collector and directory.
-    """
+def create_local_collector(tmp_path_factory: TempPathFactory, worker_pool: WorkerPool) -> tuple[LocalCollector, Path]:
+    """Create and return a local collector along with the directory it is using."""
     path = tmp_path_factory.mktemp("qpy")
-    indexer = Indexer(WorkerPool(1, 200 * MiB))
+    indexer = Indexer(worker_pool)
     return LocalCollector(path, indexer), path
 
 
@@ -69,8 +61,8 @@ class WaitForAsyncFunctionCall:
             pytest.fail(f"Function {self.func} has not been called within {timeout} seconds.", False)
 
 
-async def test_run_update_on_signal(tmp_path_factory: TempPathFactory) -> None:
-    local_collector, _ = create_local_collector(tmp_path_factory)
+async def test_run_update_on_signal(tmp_path_factory: TempPathFactory, worker_pool: WorkerPool) -> None:
+    local_collector, _ = create_local_collector(tmp_path_factory, worker_pool)
 
     async with local_collector:
         # Check that the update function is called on SIGUSR1.
@@ -83,29 +75,29 @@ async def test_run_update_on_signal(tmp_path_factory: TempPathFactory) -> None:
             mock_update.assert_awaited_once()
 
 
-async def test_ignore_files_with_wrong_extension(tmp_path_factory: TempPathFactory) -> None:
+async def test_ignore_files_with_wrong_extension(tmp_path_factory: TempPathFactory, worker_pool: WorkerPool) -> None:
     # File exists before initializing.
     directory = tmp_path_factory.mktemp("qpy")
     ignore_file = directory / "wrong.extension"
     ignore_file.touch()
 
-    indexer = Indexer(WorkerPool(1, 200 * MiB))
+    indexer = Indexer(worker_pool)
     local_collector = LocalCollector(directory, indexer)
 
     async with local_collector:
         assert len(local_collector.map.paths) == 0
 
     # File gets created after initialization.
-    local_collector, directory = create_local_collector(tmp_path_factory)
+    local_collector, directory = create_local_collector(tmp_path_factory, worker_pool)
     async with local_collector:
         ignore_file = directory / "wrong.extension"
         ignore_file.touch()
         assert len(local_collector.map.paths) == 0
 
 
-async def test_package_exists_before_init(tmp_path_factory: TempPathFactory) -> None:
+async def test_package_exists_before_init(tmp_path_factory: TempPathFactory, worker_pool: WorkerPool) -> None:
     path = tmp_path_factory.mktemp("qpy")
-    indexer = Indexer(WorkerPool(1, 200 * MiB))
+    indexer = Indexer(worker_pool)
     local_collector = LocalCollector(path, indexer)
 
     package_path = copy(PACKAGE.path, path)
@@ -119,8 +111,8 @@ async def test_package_exists_before_init(tmp_path_factory: TempPathFactory) -> 
         assert calculate_hash(actual_package_path) == package.hash
 
 
-async def test_package_gets_created(tmp_path_factory: TempPathFactory) -> None:
-    local_collector, directory = create_local_collector(tmp_path_factory)
+async def test_package_gets_created(tmp_path_factory: TempPathFactory, worker_pool: WorkerPool) -> None:
+    local_collector, directory = create_local_collector(tmp_path_factory, worker_pool)
 
     package = Package(PACKAGE.hash, PACKAGE.manifest)
 
@@ -135,8 +127,8 @@ async def test_package_gets_created(tmp_path_factory: TempPathFactory) -> None:
             assert package_path == await local_collector.get_path(package)
 
 
-async def test_package_gets_modified(tmp_path_factory: TempPathFactory) -> None:
-    local_collector, directory = create_local_collector(tmp_path_factory)
+async def test_package_gets_modified(tmp_path_factory: TempPathFactory, worker_pool: WorkerPool) -> None:
+    local_collector, directory = create_local_collector(tmp_path_factory, worker_pool)
 
     package_path = Path(copy(PACKAGE.path, directory))
     package_1 = Package(PACKAGE.hash, PACKAGE.manifest)
@@ -160,8 +152,8 @@ async def test_package_gets_modified(tmp_path_factory: TempPathFactory) -> None:
             assert Path(package_path) == await local_collector.get_path(package_2)
 
 
-async def test_package_gets_deleted(tmp_path_factory: TempPathFactory) -> None:
-    local_collector, directory = create_local_collector(tmp_path_factory)
+async def test_package_gets_deleted(tmp_path_factory: TempPathFactory, worker_pool: WorkerPool) -> None:
+    local_collector, directory = create_local_collector(tmp_path_factory, worker_pool)
 
     # Create a package in the directory.
     package_path = Path(copy(PACKAGE.path, directory))
@@ -179,8 +171,10 @@ async def test_package_gets_deleted(tmp_path_factory: TempPathFactory) -> None:
                 await local_collector.get_path(package)
 
 
-async def test_package_gets_moved_from_package_to_package(tmp_path_factory: TempPathFactory) -> None:
-    local_collector, directory = create_local_collector(tmp_path_factory)
+async def test_package_gets_moved_from_package_to_package(
+    tmp_path_factory: TempPathFactory, worker_pool: WorkerPool
+) -> None:
+    local_collector, directory = create_local_collector(tmp_path_factory, worker_pool)
 
     # Create a package in the directory.
     src_path = Path(copy(PACKAGE.path, directory))
@@ -204,8 +198,10 @@ async def test_package_gets_moved_from_package_to_package(tmp_path_factory: Temp
             assert dest_path == await local_collector.get_path(package)
 
 
-async def test_package_gets_moved_from_non_package_to_package(tmp_path_factory: TempPathFactory) -> None:
-    local_collector, directory = create_local_collector(tmp_path_factory)
+async def test_package_gets_moved_from_non_package_to_package(
+    tmp_path_factory: TempPathFactory, worker_pool: WorkerPool
+) -> None:
+    local_collector, directory = create_local_collector(tmp_path_factory, worker_pool)
 
     # Create a package in the directory.
     src_path = Path(copy(PACKAGE.path, directory / "non.package"))
@@ -223,8 +219,10 @@ async def test_package_gets_moved_from_non_package_to_package(tmp_path_factory: 
             assert dest_path == await local_collector.get_path(package)
 
 
-async def test_package_gets_moved_from_package_to_non_package(tmp_path_factory: TempPathFactory) -> None:
-    local_collector, directory = create_local_collector(tmp_path_factory)
+async def test_package_gets_moved_from_package_to_non_package(
+    tmp_path_factory: TempPathFactory, worker_pool: WorkerPool
+) -> None:
+    local_collector, directory = create_local_collector(tmp_path_factory, worker_pool)
 
     # Create a package in the directory.
     src_path = Path(copy(PACKAGE.path, directory))
@@ -244,7 +242,9 @@ async def test_package_gets_moved_from_package_to_non_package(tmp_path_factory: 
 
 
 @pytest.mark.parametrize("inside", [True, False])
-async def test_package_gets_moved_to_different_folder(tmp_path_factory: TempPathFactory, inside: bool) -> None:
+async def test_package_gets_moved_to_different_folder(
+    tmp_path_factory: TempPathFactory, inside: bool, worker_pool: WorkerPool
+) -> None:
     # Create directories.
     directory = tmp_path_factory.mktemp("qpy")
     new_directory = directory / "new"
@@ -254,7 +254,7 @@ async def test_package_gets_moved_to_different_folder(tmp_path_factory: TempPath
         # Use new_directory as the directory to be watched and directory to be the new directory of the package.
         directory, new_directory = new_directory, directory
 
-    indexer = Indexer(WorkerPool(1, 200 * MiB))
+    indexer = Indexer(worker_pool)
     local_collector = LocalCollector(directory, indexer)
 
     # Create a package in the directory.
@@ -273,8 +273,8 @@ async def test_package_gets_moved_to_different_folder(tmp_path_factory: TempPath
                 await local_collector.get_path(package)
 
 
-async def test_package_filenames_get_swapped(tmp_path_factory: TempPathFactory) -> None:
-    local_collector, directory = create_local_collector(tmp_path_factory)
+async def test_package_filenames_get_swapped(tmp_path_factory: TempPathFactory, worker_pool: WorkerPool) -> None:
+    local_collector, directory = create_local_collector(tmp_path_factory, worker_pool)
 
     package_1_path = Path(copy(PACKAGE.path, directory))
     package_1 = Package(PACKAGE.hash, PACKAGE.manifest)
@@ -304,8 +304,10 @@ async def test_package_filenames_get_swapped(tmp_path_factory: TempPathFactory) 
             mock_unregister.assert_not_awaited()
 
 
-async def test_local_collector_is_resilient_to_faulty_packages(tmp_path_factory: TempPathFactory) -> None:
-    local_collector, directory = create_local_collector(tmp_path_factory)
+async def test_local_collector_is_resilient_to_faulty_packages(
+    tmp_path_factory: TempPathFactory, worker_pool: WorkerPool
+) -> None:
+    local_collector, directory = create_local_collector(tmp_path_factory, worker_pool)
 
     invalid_package_content = b"this is a invalid package"
     invalid_package_path = directory / "invalid.qpy"

--- a/tests/questionpy_server/worker/impl/test_subprocess.py
+++ b/tests/questionpy_server/worker/impl/test_subprocess.py
@@ -24,13 +24,9 @@ from tests.conftest import PACKAGE
 from tests.questionpy_server.worker.impl.conftest import patch_worker_pool
 
 
-@pytest.fixture
-def pool() -> WorkerPool:
-    return WorkerPool(1, 512 * MiB, worker_type=SubprocessWorker)
-
-
-async def test_should_apply_limits(pool: WorkerPool) -> None:
-    async with pool.get_worker(PACKAGE, 1, 1) as worker:
+@pytest.mark.parametrize("worker_pool", [SubprocessWorker], indirect=True)
+async def test_should_apply_limits(worker_pool: WorkerPool) -> None:
+    async with worker_pool.get_worker(PACKAGE, 1, 1) as worker:
         assert isinstance(worker, SubprocessWorker)
         assert worker._proc
         # Python's resource package can only get the rlimit of other processes on Linux, so we use psutil.
@@ -51,12 +47,13 @@ def _make_get_manifest_busy_wait() -> Iterator[None]:
         yield
 
 
-async def test_should_raise_cpu_timout_error(pool: WorkerPool) -> None:
-    with patch_worker_pool(pool, _make_get_manifest_busy_wait):
+@pytest.mark.parametrize("worker_pool", [SubprocessWorker], indirect=True)
+async def test_should_raise_cpu_timout_error(worker_pool: WorkerPool) -> None:
+    with patch_worker_pool(worker_pool, _make_get_manifest_busy_wait):
         start_time = time()
         # Change the timeout for faster testing.
         with pytest.raises(WorkerStartError) as exc_info, patch.object(BaseWorker, "_init_worker_timeout", 0.05):
-            async with pool.get_worker(PACKAGE, 1, 1):
+            async with worker_pool.get_worker(PACKAGE, 1, 1):
                 pass
         assert isinstance(exc_info.value.__cause__, WorkerCPUTimeLimitExceededError)
         assert 0.05 < (time() - start_time) < 0.5
@@ -71,8 +68,9 @@ def _make_get_manifest_sleep() -> Iterator[None]:
         yield
 
 
-async def test_should_raise_real_timout_error(pool: WorkerPool) -> None:
-    with patch_worker_pool(pool, _make_get_manifest_sleep):
+@pytest.mark.parametrize("worker_pool", [SubprocessWorker], indirect=True)
+async def test_should_raise_real_timout_error(worker_pool: WorkerPool) -> None:
+    with patch_worker_pool(worker_pool, _make_get_manifest_sleep):
         # The timeout should not be too short, because the Python interpreter also needs some time to start up, which
         # is accounted for the init worker step. Otherwise, a WorkerCPUTimeLimitExceededError is raised.
         start_time = time()
@@ -82,7 +80,7 @@ async def test_should_raise_real_timout_error(pool: WorkerPool) -> None:
             patch.object(BaseWorker, "_init_worker_timeout", 0.6),
             patch.object(LimitTimeUsageMixin, "_real_time_limit_factor", 1.0),
         ):
-            async with pool.get_worker(PACKAGE, 1, 1) as worker:
+            async with worker_pool.get_worker(PACKAGE, 1, 1) as worker:
                 await worker.get_manifest()
         assert isinstance(exc_info.value.__cause__, WorkerRealTimeLimitExceededError)
         assert 0.6 < (time() - start_time) < 2.0

--- a/tests/questionpy_server/worker/impl/test_thread.py
+++ b/tests/questionpy_server/worker/impl/test_thread.py
@@ -7,20 +7,15 @@ from unittest.mock import patch
 
 import pytest
 
-from questionpy_common.constants import MiB
 from questionpy_server import WorkerPool
 from questionpy_server.worker.impl.thread import ThreadWorker
 from tests.conftest import PACKAGE
 
 
-@pytest.fixture
-def pool() -> WorkerPool:
-    return WorkerPool(1, 512 * MiB, worker_type=ThreadWorker)
-
-
-async def test_should_ignore_limits(pool: WorkerPool) -> None:
+@pytest.mark.parametrize("worker_pool", [ThreadWorker], indirect=True)
+async def test_should_ignore_limits(worker_pool: WorkerPool) -> None:
     with patch.object(resource, "setrlimit") as mock:
-        async with pool.get_worker(PACKAGE, 1, 1):
+        async with worker_pool.get_worker(PACKAGE, 1, 1):
             pass
 
         mock.assert_not_called()


### PR DESCRIPTION
Closes #143.

Da der `ThreadWorker` die `WorkerResourceLimits` ignoriert, ist es mit der aktuellen Implementierung theoretisch möglich "unbegrenzt" viele `ThreadWorker` zu erstellen. Da der Worker nur zum Debuggen verwendet wird, habe ich keine extra Logik eingebaut, die die Anzahl der `ThreadWorker` beschränkt. 

Performance-Beispiel: Beim Aufruf von `/packages/{hash}/question` habe ich auf meiner Maschine folgende Verbesserung der Antwortzeiten erzielt:
  * `ProcessWorker` ca. 20x (500ms -> 25ms)
  * `ThreadWorker` ca.     4.5x (90ms -> 20ms)