### PR TITLE
Subprocess-Worker: Faulthandler und Output filtern und sofort loggen

### DIFF
--- a/questionpy_server/worker/impl/_base.py
+++ b/questionpy_server/worker/impl/_base.py
@@ -87,7 +87,7 @@ class BaseWorker(Worker, ABC):
 
         self._connection: ServerToWorkerConnection | None = None
         self._expected_incoming_messages: list[tuple[MessageIds, asyncio.Future]] = []
-        self._receive_messages_exception: BaseException | None = None
+        self._exception: BaseException | None = None
 
     async def _initialize(self) -> None:
         """Initializes an already running worker and starts the observe task.
@@ -164,7 +164,7 @@ class BaseWorker(Worker, ABC):
         finally:
             for _, future in self._expected_incoming_messages:
                 if not future.done():
-                    exc = self._receive_messages_exception or WorkerNotRunningError(worker_name=self.name)
+                    exc = self._exception or WorkerNotRunningError(worker_name=self.name)
                     future.set_exception(exc)
             self._expected_incoming_messages = []
 
@@ -187,7 +187,7 @@ class BaseWorker(Worker, ABC):
             for task in done:
                 with contextlib.suppress(asyncio.CancelledError):
                     if exc := task.exception():
-                        self._receive_messages_exception = exc
+                        self._exception = exc
         finally:
             await self.kill()
 

--- a/questionpy_server/worker/impl/subprocess.py
+++ b/questionpy_server/worker/impl/subprocess.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import math
 import re
+import signal
 import sys
 from asyncio import StreamReader
 from collections.abc import Sequence
@@ -17,7 +18,12 @@ from pydantic import ByteSize
 from questionpy_common.constants import KiB
 from questionpy_server.worker import WorkerArgs, WorkerResources
 from questionpy_server.worker.connection import ServerToWorkerConnection
-from questionpy_server.worker.exception import WorkerNotRunningError, WorkerStartError
+from questionpy_server.worker.exception import (
+    WorkerCPUTimeLimitExceededError,
+    WorkerNotRunningError,
+    WorkerRealTimeLimitExceededError,
+    WorkerStartError,
+)
 from questionpy_server.worker.impl._base import BaseWorker, LimitTimeUsageMixin
 from questionpy_server.worker.runtime.messages import MessageToServer, MessageToWorker
 
@@ -187,6 +193,22 @@ class SubprocessWorker(BaseWorker, LimitTimeUsageMixin):
 
     async def kill(self) -> None:
         if self._proc and self._proc.returncode is None:
+            if self._exception and (
+                isinstance(self._exception, WorkerRealTimeLimitExceededError | WorkerCPUTimeLimitExceededError)
+            ):
+                # If the worker has to be killed because of a real-time or CPU-time limit, send an abort signal to the
+                # worker that will make it to dump a Python traceback (thanks to the fault handler).
+                self._proc.send_signal(signal.SIGABRT)
+
+                # We give it a short time to dump the traceback. Usually, SIGABRT should terminate the process
+                # right after Python's signal handler returns.
+                try:
+                    await asyncio.wait_for(self._proc.wait(), 0.2)
+                except TimeoutError:
+                    log.warning("Worker %s did not terminate after SIGABRT", self.name)
+                else:
+                    return
+
             self._proc.kill()
 
             # Make sure that all resources of the subprocesses are getting cleaned.

--- a/questionpy_server/worker/impl/subprocess.py
+++ b/questionpy_server/worker/impl/subprocess.py
@@ -139,6 +139,7 @@ class SubprocessWorker(BaseWorker, LimitTimeUsageMixin):
             stderr=asyncio.subprocess.PIPE,
             env=env,
             cwd=self.worker_home,
+            start_new_session=True,
         )
 
         if self._proc.stdout is None or self._proc.stderr is None or self._proc.stdin is None:

--- a/questionpy_server/worker/impl/subprocess.py
+++ b/questionpy_server/worker/impl/subprocess.py
@@ -5,6 +5,7 @@
 import asyncio
 import logging
 import math
+import re
 import sys
 from asyncio import StreamReader
 from collections.abc import Sequence
@@ -30,17 +31,36 @@ _T = TypeVar("_T", bound=MessageToServer)
 class _StderrBuffer:
     """Size-limited buffer for untrusted worker output."""
 
-    def __init__(self, stderr: StreamReader):
+    _control_char_pattern = re.compile(r"[\x00-\x09\x0b-\x1f\x7f]")
+    """A regex pattern to match all control characters except newline."""
+
+    def __init__(self, worker_name: str, stderr: StreamReader):
+        self._worker_name = worker_name
         self._stderr = stderr
         self._buffer = bytearray()
         self._max_size = 5 * KiB
         self._skipped_bytes = 0
 
+    @classmethod
+    def _remove_ascii_control_characters(cls, data: str) -> str:
+        """Replace ASCII control characters with their hex representation and remove newline/whitespaces at the end."""
+        return cls._control_char_pattern.sub(lambda m: f"\\x{ord(m.group()):02x}", data).rstrip()
+
     async def read_stderr(self) -> None:
         """Read and save data written by the worker to stderr (worker is set up to redirect stdout to stderr).
 
-        Only read up to a certain amount due to security reasons and stderr should not be used besides debugging.
+        Normally, data is only read up to a certain amount for security reasons and stderr should not be used
+        besides debugging. If debug log level is enabled, read stderr line by line and log all data immediately.
+
+        ASCII control characters are replaced, especially the escape character and ANSI escape codes should have
+        no effect.
         """
+        if log.isEnabledFor(logging.DEBUG):
+            while line := await self._stderr.readline():
+                cleaned = self._remove_ascii_control_characters(line.decode(errors="replace"))
+                log.debug("Worker %s output: %s", self._worker_name, cleaned)
+            return
+
         while True:
             space_left = self._max_size - len(self._buffer)
             if space_left == 0:
@@ -59,12 +79,20 @@ class _StderrBuffer:
 
     def flush(self) -> None:
         """Reset the stderr buffer and log the current data."""
-        if self._buffer and log.isEnabledFor(logging.DEBUG):
-            msg = "Worker wrote following data to stdout/stderr."
+        if self._buffer and log.isEnabledFor(logging.INFO):
+            skipped_bytes_msg = ""
             if self._skipped_bytes:
-                msg += f" (Additional {ByteSize(self._skipped_bytes).human_readable()} were skipped.)"
-            indented_data = "\n".join("\t" + line for line in self._buffer.decode(errors="replace").split("\n"))
-            log.debug("%s\n%s", msg, indented_data)
+                skipped_bytes_msg = f"\n\t  (additional {ByteSize(self._skipped_bytes).human_readable()} were skipped)"
+            indented_data = "\n".join(
+                "\t" + self._remove_ascii_control_characters(line)
+                for line in self._buffer.decode(errors="replace").split("\n")
+            )
+            log.info(
+                "Worker %s wrote following data to stdout/stderr:\n%s%s",
+                self._worker_name,
+                indented_data,
+                skipped_bytes_msg,
+            )
 
         self._buffer = bytearray()
         self._skipped_bytes = 0
@@ -111,7 +139,7 @@ class SubprocessWorker(BaseWorker, LimitTimeUsageMixin):
             msg = "Could not start the worker process."
             raise WorkerStartError(msg, worker_name=self.name)
 
-        self._stderr_buffer = _StderrBuffer(self._proc.stderr)
+        self._stderr_buffer = _StderrBuffer(self.name, self._proc.stderr)
         self._connection = ServerToWorkerConnection(self._proc.stdout, self._proc.stdin)
 
         try:

--- a/questionpy_server/worker/runtime/subprocess_main.py
+++ b/questionpy_server/worker/runtime/subprocess_main.py
@@ -2,6 +2,7 @@
 #  The QuestionPy Server is free software released under terms of the MIT license. See LICENSE.md.
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
 
+import faulthandler
 import sys
 from io import BufferedReader, FileIO, StringIO
 
@@ -26,6 +27,10 @@ def _setup_server_communication() -> WorkerToServerConnection:
 
 def subprocess_runtime_main() -> None:
     sys.dont_write_bytecode = True
+
+    # Enable the fault handler to dump stack traces to stderr when certain errors/signals occur.
+    faulthandler.enable()
+
     con = _setup_server_communication()
     manager = WorkerManager(con)
     manager.bootstrap()


### PR DESCRIPTION
* Bei debug Log-Level sollen die Ausgaben des Workers im stderr sofort ausgegeben werden.
* Andernfalls werden die stderr Ausgaben als INFO nun geloggt.
* ASCII Control Characters werden aus Sicherheitsgründen ersetzt. Besonders die ANSI Escape Codes sollen nicht im Terminal ankommen.
* Der Faulthandler von Python wird aktiviert und dem Prozess wird ein SIGABRT geschickt, wenn er wegen einer Zeitüberschreitung gestoppt werden soll.
https://docs.python.org/3/library/faulthandler.html

Mit diesen Maßnahmen soll das Debugging verbessert werden.