### PR TITLE
feat!: move TranslatableString transformations into SDK

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "questionpy-server"
 description = "QuestionPy application server"
 license = { file = "LICENSE.md" }
 urls = { homepage = "https://questionpy.org" }
-version = "0.6.1"
+version = "0.7.0"
 authors = [
     { name = "TU Berlin innoCampus" },
     { email = "info@isis.tu-berlin.de" }

--- a/questionpy_common/__init__.py
+++ b/questionpy_common/__init__.py
@@ -1,27 +1,22 @@
 #  This file is part of QuestionPy. (https://questionpy.org)
 #  QuestionPy is free software released under terms of the MIT license. See LICENSE.md.
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
-
-from collections.abc import Mapping
-from typing import Protocol, runtime_checkable
+from abc import ABC, abstractmethod
 
 from pydantic_core import CoreSchema, core_schema
 
 
-@runtime_checkable
-class TranslatableString(Protocol):
+class TranslatableString(ABC):
     """Protocol for strings which may be lazily retrieved, such as deferred translations."""
 
+    @abstractmethod
     def __str__(self) -> str:
         """Translate this string."""
-
-    def format(self, *args: object, **kwargs: object) -> "str | TranslatableString":
-        """Perform the same formatting as [`str.format`][], possibly lazily."""
-
-    def format_map(self, mapping: Mapping[str, object]) -> "str | TranslatableString":
-        """Perform the same formatting as [`str.format_map`][], possibly lazily."""
 
     @classmethod
     def __get_pydantic_core_schema__(cls, *_: object) -> CoreSchema:
         # Never convert anything to a TranslatableString, but accept existing instances, and serialize by using str().
         return core_schema.is_instance_schema(cls, serialization=core_schema.to_string_ser_schema())
+
+
+TranslatableString.register(str)


### PR DESCRIPTION
Beim Erweitern der `TranslatableString`-Klasse ist mir aufgefallen, dass sie zwar mit Blick auf <https://github.com/questionpy-org/questionpy-server/pull/136#issuecomment-2694018715> in `questionpy_common` definiert sein muss, der Server aber nicht von den Transformations-Methoden gebrauch macht, und die deshalb nicht Teil des Protocols sein müssen. Damit nicht jedes Objekt `TranslatableString` erfüllt, habe ich eine `ABC` daraus gemacht und `str` manuell registriert.

SDK-PR: <https://github.com/questionpy-org/questionpy-sdk/pull/190>