### PR TITLE
Anpassung der QPPE and den aktuellen Stand

### DIFF
--- a/docs/.spectral.yaml
+++ b/docs/.spectral.yaml
@@ -1,0 +1,7 @@
+extends: "spectral:oas"
+rules:
+  info-contact: off
+  info-description: off
+  operation-description: off
+  operation-operationId: off
+  operation-tags: off

--- a/docs/lint.sh
+++ b/docs/lint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -o errexit
+
+cd "$(dirname "$0")"
+exec npx "@stoplight/spectral-cli@^6.15.0" lint qppe-server.yaml qppe-lms.yaml

--- a/docs/qppe-lms.yaml
+++ b/docs/qppe-lms.yaml
@@ -14,16 +14,16 @@ paths:
       security:
         - AuthPackageAccess: [ ]
       responses:
-        200:
+        "200":
           description: OK
           content:
             application/octet-stream:
               schema:
                 type: string
                 format: binary
-        401:
+        "401":
           description: Access token is missing or invalid.
-        404:
+        "404":
           description: Not Found
 
   /question/{question_ref}/attempt/{attempt_ref}/response/{response_ref}/fields/{field}/files/{file_ref}:
@@ -43,9 +43,9 @@ paths:
       security:
         - AuthQuestionAttemptAccess: [ ]
       responses:
-        200:
+        "200":
           description: OK
-        401:
+        "401":
           description: Access token is missing or invalid.
 
   /question/{question_ref}/attempt/{attempt_ref}/response/{response_ref}/previous-responses:
@@ -58,13 +58,13 @@ paths:
       security:
         - AuthQuestionAttemptAccess: [ ]
       responses:
-        200:
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ResponsesList"
-        401:
+        "401":
           description: Access token is missing or invalid.
 
   /question/{question_ref}/attempt/{attempt_ref}/response/{response_ref}/score/{scoring_job_uuid}:
@@ -83,16 +83,16 @@ paths:
           application/json:
             schema:
               oneOf:
-                - $ref: 'qppe-server.yaml#/components/schemas/AttemptAsyncScoringStatusFinished'
-                - $ref: 'qppe-server.yaml#/components/schemas/AttemptAsyncScoringStatusError'
+                - $ref: '#/components/schemas/AttemptAsyncScoringStatusFinished'
+                - $ref: '#/components/schemas/AttemptAsyncScoringStatusError'
               discriminator:
                 propertyName: job_status
       responses:
-        204:
+        "204":
           description: OK
-        401:
+        "401":
           description: Access token is missing or invalid.
-        404:
+        "404":
           description: Scoring job uuid is unknown.
 
   /question/{question_ref}/attempt/{attempt_ref}/response/{response_ref}/scoring/files:
@@ -105,7 +105,7 @@ paths:
       security:
         - AuthQuestionAttemptAccess: [ ]
       responses:
-        200:
+        "200":
           description: OK
           content:
             application/json:
@@ -121,11 +121,11 @@ paths:
     get:
       summary: Get a file that was created by a package during scoring.
       security:
-        - AuthQuestionAttemptToken: [ ]
+        - AuthQuestionAttemptAccess: [ ]
       responses:
-        200:
+        "200":
           description: OK
-        401:
+        "401":
           description: Access token is missing or invalid.
     put:
       summary: Create a scoring file.
@@ -138,11 +138,11 @@ paths:
           schema:
             type: string
       responses:
-        201:
+        "201":
           description: File created successfully.
-        401:
+        "401":
           description: Access token is missing or invalid.
-        413:
+        "413":
           description: File is too large or not enough space for this file.
 
 
@@ -154,13 +154,13 @@ paths:
       security:
         - AuthQuestionAccess: [ ]
       responses:
-        200:
+        "200":
           description: OK
           content:
             application/json:
               schema:
                  $ref: "#/components/schemas/QuestionFilesList"
-        401:
+        "401":
           description: Access token is missing or invalid.
 
   /question/{question_ref}/files/{file_name}:
@@ -172,9 +172,9 @@ paths:
       security:
         - AuthQuestionAccess: [ ]
       responses:
-        200:
+        "200":
           description: OK
-        401:
+        "401":
           description: Access token is missing or invalid.
     put:
       summary: Create or update a file.
@@ -189,11 +189,11 @@ paths:
           schema:
             type: string
       responses:
-        201:
+        "201":
           description: File created successfully.
-        401:
+        "401":
           description: Access token is missing or invalid.
-        413:
+        "413":
           description: File is too large or not enough space for this file.
 
   /question/{question_ref}/options/files/{file_ref}:
@@ -206,9 +206,9 @@ paths:
         - AuthQuestionAccess: [ ]
         - AuthNewQuestionCreate: [ ]
       responses:
-        200:
+        "200":
           description: OK
-        401:
+        "401":
           description: Access token is missing or invalid.
 
   /question/{question_ref}/state:
@@ -219,15 +219,15 @@ paths:
       security:
         - AuthQuestionAccess: [ ]
       responses:
-        200:
+        "200":
           description: OK
           content:
             text/plain:
               schema:
                 type: string
-        401:
+        "401":
           description: Access token is missing or invalid.
-        404:
+        "404":
           description: Not Found
 
 components:
@@ -291,6 +291,18 @@ components:
       pattern: '^[a-zA-Z0-9\-_=]{1,64}$'
       description: A question attempt reference that is determined by the LMS. It uniquely identifies an attempt
         of a question.
+
+    AttemptAsyncScoringStatusFinished:
+      type: object
+      allOf:
+        - $ref: "qppe-server.yaml#/components/schemas/AttemptAsyncScoringStatus"
+        - $ref: "qppe-server.yaml#/components/schemas/AttemptScored"
+
+    AttemptAsyncScoringStatusError:
+      type: object
+      allOf:
+        - $ref: "qppe-server.yaml#/components/schemas/AttemptAsyncScoringStatus"
+        - $ref: "qppe-server.yaml#/components/schemas/RequestError"
 
     ResponseRef:
       type: string

--- a/docs/qppe-server.yaml
+++ b/docs/qppe-server.yaml
@@ -12,7 +12,7 @@ paths:
     get:
       summary: Get all available packages
       responses:
-        200:
+        "200":
           description: OK
           content:
             application/json:
@@ -20,7 +20,7 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/PackageVersionsInfo"
-        401:
+        "401":
           $ref: '#/components/responses/UnauthorizedError'
 
   /packages/{package_hash}:
@@ -31,15 +31,15 @@ paths:
     get:
       summary: Get a specific package info by its hash
       responses:
-        200:
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/PackageVersionInfo"
-        401:
+        "401":
           $ref: '#/components/responses/UnauthorizedError'
-        404:
+        "404":
           description: Not Found
 
   /packages/{package_hash}/options:
@@ -59,7 +59,7 @@ paths:
             schema:
               $ref: "#/components/schemas/RequestBaseData"
       responses:
-        200:
+        "200":
           description: Definition that can be used in order to display a form.
           headers:
             Content-Language:
@@ -68,11 +68,11 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/QuestionEditForm"
-        401:
+        "401":
           $ref: '#/components/responses/UnauthorizedError'
-        404:
+        "404":
           description: Package not found.
-        500:
+        "500":
           description: Error occurred.
           content:
             application/json:
@@ -97,7 +97,7 @@ paths:
             schema:
               $ref: "#/components/schemas/QuestionCreateArguments"
       responses:
-        201:
+        "201":
           description: Successful
           headers:
             Content-Language:
@@ -106,11 +106,11 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/QuestionCreated"
-        401:
+        "401":
           $ref: '#/components/responses/UnauthorizedError'
-        404:
+        "404":
           description: Package not found.
-        422:
+        "422":
           description: Validation error
           headers:
             Content-Language:
@@ -119,7 +119,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/OptionsFormValidationError"
-        500:
+        "500":
           description: Error occurred.
           content:
             application/json:
@@ -142,13 +142,13 @@ paths:
             schema:
               $ref: "#/components/schemas/QuestionMigrateArguments"
       responses:
-        200:
+        "200":
           description: Successfully updated data
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/QuestionCreated"
-        400:
+        "400":
           description: Question state migration error
           headers:
             Content-Language:
@@ -157,11 +157,11 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/QuestionStateMigrationError"
-        401:
+        "401":
           $ref: '#/components/responses/UnauthorizedError'
-        404:
+        "404":
           description: Package not found.
-        500:
+        "500":
           description: Error occurred.
           content:
             application/json:
@@ -184,7 +184,7 @@ paths:
             schema:
               $ref: "#/components/schemas/RequestBaseData"
       responses:
-        200:
+        "200":
           description: OK
           headers:
             Content-Language:
@@ -193,11 +193,11 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Question"
-        401:
+        "401":
           $ref: '#/components/responses/UnauthorizedError'
-        404:
+        "404":
           description: Package not found.
-        500:
+        "500":
           description: Error occurred.
           content:
             application/json:
@@ -219,7 +219,7 @@ paths:
             schema:
               $ref: "#/components/schemas/AttemptStartArguments"
       responses:
-        201:
+        "201":
           description: Attempt started data
           headers:
             Content-Language:
@@ -228,11 +228,11 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AttemptStarted"
-        401:
+        "401":
           $ref: '#/components/responses/UnauthorizedError'
-        404:
+        "404":
           description: Package not found.
-        500:
+        "500":
           description: Error occurred.
           content:
             application/json:
@@ -254,7 +254,7 @@ paths:
             schema:
               $ref: "#/components/schemas/AttemptViewArguments"
       responses:
-        200:
+        "200":
           description: Attempt view data
           headers:
             Content-Language:
@@ -263,11 +263,11 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Attempt"
-        401:
+        "401":
           $ref: '#/components/responses/UnauthorizedError'
-        404:
+        "404":
           description: Package not found.
-        500:
+        "500":
           description: Error occurred.
           content:
             application/json:
@@ -290,7 +290,7 @@ paths:
             schema:
               $ref: "#/components/schemas/AttemptScoreArguments"
       responses:
-        200:
+        "200":
           description: Scored attempt data
           headers:
             Content-Language:
@@ -299,7 +299,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AttemptScored"
-        202:
+        "202":
           description: Attempt will be scored asynchronously.
           content:
             application/json:
@@ -310,11 +310,11 @@ paths:
                     type: string
                     description: Async scoring job uuid.
                 required: [ scoring_job_uuid ]
-        401:
+        "401":
           $ref: '#/components/responses/UnauthorizedError'
-        404:
+        "404":
           description: Package not found.
-        500:
+        "500":
           description: Error occurred.
           content:
             application/json:
@@ -329,24 +329,24 @@ paths:
     get:
       summary: Get status of an asynchronous scoring job.
       responses:
-        200:
+        "200":
           description: status
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/AttemptAsyncScoringStatus'
-        401:
+        "401":
           $ref: '#/components/responses/UnauthorizedError'
-        404:
+        "404":
           description: Job not found.
     delete:
       summary: Cancel an asynchronous scoring job.
       responses:
-        204:
+        "204":
           description: Job cancelled.
-        401:
+        "401":
           $ref: '#/components/responses/UnauthorizedError'
-        404:
+        "404":
           description: Job not found.
 
   /packages/{package_hash}/file/{namespace}/{short_name}/{path}:
@@ -384,15 +384,15 @@ paths:
             schema:
               $ref: "#/components/schemas/RequestBaseData"
       responses:
-        200:
+        "200":
           description: Static file data
           content:
             "*/*": {}
-        401:
+        "401":
           $ref: '#/components/responses/UnauthorizedError'
-        404:
+        "404":
           description: Package or its static file not found.
-        500:
+        "500":
           description: Error occurred.
           content:
             application/json:
@@ -418,15 +418,15 @@ paths:
                   description: QuestionPy Package
               required: [ package ]
       responses:
-        201:
+        "201":
           description: OK
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/PackageVersionInfo"
-        401:
+        "401":
           $ref: '#/components/responses/UnauthorizedError'
-        500:
+        "500":
           description: Error occurred.
           content:
             application/json:
@@ -439,13 +439,13 @@ paths:
     get:
       summary: Get information about the server status
       responses:
-        200:
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ServerStatus"
-        401:
+        "401":
           $ref: '#/components/responses/UnauthorizedError'
 
 components:
@@ -563,6 +563,8 @@ components:
           nullable: true
         tags:
           type: array
+          items:
+            type: string
           default: [ ]
           uniqueItems: true
       required: [ short_name, namespace, name, type, author, url, languages, description, icon, license ]
@@ -994,50 +996,54 @@ components:
             scored_inputs:
               type: object
               default: { }
-              properties:
-                state:
-                  type: string
-                  enum:
-                    - CORRECT
-                    - CONSEQUENTIAL_SCORE
-                    - PARTIALLY_CORRECT
-                    - WRONG
-                score:
-                  type: number
-                  format: double
-                  nullable: true
-                  default: null
-              required: [ state ]
+              additionalProperties:
+                type: object
+                properties:
+                  state:
+                    type: string
+                    enum:
+                      - CORRECT
+                      - CONSEQUENTIAL_SCORE
+                      - PARTIALLY_CORRECT
+                      - WRONG
+                  score:
+                    type: number
+                    format: double
+                    nullable: true
+                    default: null
+                required: [ state ]
               description: Maps input names to their individual scores.
             scored_subquestions:
               type: object
               default: { }
-              properties:
-                score:
-                  type: number
-                  format: double
-                  nullable: true
-                  default: null
-                score_final:
-                  type: number
-                  format: double
-                  nullable: true
-                  default: null
-                scoring_code:
-                  type: string
-                  enum:
-                    - AUTOMATICALLY_SCORED
-                    - NEEDS_MANUAL_SCORING
-                    - RESPONSE_NOT_SCORABLE
-                    - INVALID_RESPONSE
-                  nullable: true
-                  default: null
-                response_summary:
-                  type: string
-                response_class:
-                  type: string
+              additionalProperties:
+                properties:
+                  score:
+                    type: number
+                    format: double
+                    nullable: true
+                    default: null
+                  score_final:
+                    type: number
+                    format: double
+                    nullable: true
+                    default: null
+                  scoring_code:
+                    type: string
+                    enum:
+                      - AUTOMATICALLY_SCORED
+                      - NEEDS_MANUAL_SCORING
+                      - RESPONSE_NOT_SCORABLE
+                      - INVALID_RESPONSE
+                      - null
+                    nullable: true
+                    default: null
+                  response_summary:
+                    type: string
+                  response_class:
+                    type: string
+                required: [ response_summary, response_class ]
               description: Maps subquestion IDs to their individual score.
-              required: [ response_summary, response_class ]
             hint:
               type: string
               nullable: true
@@ -1114,18 +1120,6 @@ components:
             * `FINISHED` - The job finished successfully.
             * `ERROR` - An error occurred.
       required: [ job_status ]
-
-    AttemptAsyncScoringStatusFinished:
-      type: object
-      allOf:
-        - $ref: "#/components/schemas/AttemptAsyncScoringStatus"
-        - $ref: "#/components/schemas/AttemptScored"
-
-    AttemptAsyncScoringStatusError:
-      type: object
-      allOf:
-        - $ref: "#/components/schemas/AttemptAsyncScoringStatus"
-        - $ref: "#/components/schemas/RequestError"
 
     RequestError:
       type: object
@@ -1398,7 +1392,7 @@ components:
               value:
                 type: string
               selected:
-                type: string
+                type: boolean
                 description: Whether this option is initially selected
                 default: false
             required: [ label, value ]

--- a/docs/qppe-server.yaml
+++ b/docs/qppe-server.yaml
@@ -67,7 +67,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Options"
+                $ref: "#/components/schemas/QuestionEditForm"
         401:
           $ref: '#/components/responses/UnauthorizedError'
         404:
@@ -521,12 +521,13 @@ components:
           example: multiple_choice
         namespace:
           type: string
-          example: default
+          example: local
         name:
           type: object
           example:
             en: Multiple Choice
             de: Mehrfachauswahl
+          minProperties: 1
         type:
           type: string
           enum:
@@ -538,33 +539,33 @@ components:
         url:
           type: string
           nullable: true
-          default: null
         languages:
           type: array
           items:
             type: string
           example: [ en, de ]
-          default: [ ]
+          minItems: 1
         description:
           type: object
-          default: { }
+          additionalProperties:
+            type: string
           example:
             en: Multiple Choice
             de: Mehrfachauswahl
+          nullable: true
         icon:
           type: string
           format: uri
           nullable: true
-          default: null
           example: "https://example.org/favicon.ico"
         license:
           type: string
           nullable: true
-          default: null
         tags:
           type: array
           default: [ ]
-      required: [ short_name, namespace, name, type, author ]
+          uniqueItems: true
+      required: [ short_name, namespace, name, type, author, url, languages, description, icon, license ]
 
     PackageVersionSpecificInfo:
       type: object
@@ -594,6 +595,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PackageVersionSpecificInfo'
+      required: [ manifest, versions ]
 
     OptionsFormDefinition:
       type: object
@@ -626,7 +628,7 @@ components:
             - OPT_1
             - OPT_2
 
-    Options:
+    QuestionEditForm:
       type: object
       properties:
         definition:
@@ -660,7 +662,7 @@ components:
         local_package:
           type: boolean
           description: True if the LMS is able to return the .qpy file through the LMS Callback API.
-      required: [ question_ref, context, callback_url, lms_auth_token, local_package ]
+      required: [ question_ref, callback_url, lms_auth_token, local_package ]
 
     QuestionCreateArguments:
       description: Information that is needed to create a new question.
@@ -686,100 +688,82 @@ components:
               $ref: 'qppe-lms.yaml#/components/schemas/QuestionRef'
           required: [ old_question_ref ]
 
-    QuestionViewArguments:
-      description: Information that is needed to view a question.
+    Question:
       allOf:
-        - $ref: "#/components/schemas/RequestBaseData"
+        - $ref: "#/components/schemas/Localized"
         - type: object
           properties:
-            attempt_ref:
-              $ref: 'qppe-lms.yaml#/components/schemas/AttemptRef'
-            response_ref:
-              $ref: 'qppe-lms.yaml#/components/schemas/ResponseRef'
-          required: [ question_state ]
-
-    Question:
-      type: object
-      properties:
-        num_variants:
-          type: integer
-          minimum: 1
-          description: Number of available variants of this question.
-        num_subquestions:
-          type: integer
-          minimum: 1
-          description: Maximum number of subquestions that this question can have.
-        score_min:
-          type: number
-          format: double
-        score_max:
-          type: number
-          format: double
-        scoring_method:
-          type: string
-          enum:
-            - ALWAYS_MANUAL_SCORING_REQUIRED
-            - AUTOMATICALLY_SCORABLE
-            - AUTOMATICALLY_SCORABLE_WITH_COUNTBACK
-          description: AUTOMATICALLY_SCORABLE_WITH_COUNTBACK means the package is able to compute a final score,
-            taking into account previous submissions to this question.
-        penalty:
-          type: number
-          nullable: true
-          format: double
-          description: Penalty that is subtracted from the score after each failed attempt. Exact semantics TBD.
-        random_guess_score:
-          type: number
-          nullable: true
-          format: double
-          description: Average expected score when the response is just selected randomly.
-        subquestions:
-          type: array
-          nullable: true
-          description: Listing of subquestions if the question consists of subquestions.
-          items:
-            type: object
-            properties:
-              subquestion_id:
-                type: string
-                maxLength: 30
-              score_max:
-                type: number
-                format: double
-                nullable: true
-                description: Maximum score. May be null if no score can be assigned directly to this
-                  specific subquestion.
-              response_classes:
-                type: array
-                nullable: true
-                description: All the possible types of responses per subquestion. This is used for
-                  statistics in order to classify responses. Can be null if question does not
-                  support a response analysis.
-                items:
-                  type: object
-                  properties:
-                    response_class:
-                      type: string
-                      maxLength: 30
-                    score:
-                      type: number
-                      format: double
-                  required: [ response_class, score ]
-            required: [ subquestion_id, score_max, response_classes ]
-        response_analysis_by_variant:
-          type: boolean
-          description: If true, the LMS should break down the stats and response analysis by the question variant.
-        render_every_view:
-          type: boolean
-          description: The question UI should not be cached and every view should be rendered by the package.
-          default: false
-        general_feedback:
-          type: string
-          nullable: true
-          description: General feedback that is shown to everyone after scoring.
-      required: [ num_variants, num_subquestions, score_min,
-                  score_max, scoring_method, penalty, random_guess_score, subquestions,
-                  response_analysis_by_variant, render_every_view, general_feedback ]
+            num_variants:
+              type: integer
+              default: 1
+              minimum: 1
+              description: Number of available variants of this question.
+            score_min:
+              type: number
+              format: double
+              default: 0
+            score_max:
+              type: number
+              format: double
+              default: 1
+            scoring_method:
+              type: string
+              enum:
+                - ALWAYS_MANUAL_SCORING_REQUIRED
+                - AUTOMATICALLY_SCORABLE
+                - AUTOMATICALLY_SCORABLE_WITH_COUNTBACK
+              description: AUTOMATICALLY_SCORABLE_WITH_COUNTBACK means the package is able to compute a final score,
+                taking into account previous submissions to this question.
+            penalty:
+              type: number
+              format: double
+              nullable: true
+              default: null
+              description: Penalty that is subtracted from the score after each failed attempt. Exact semantics TBD.
+            random_guess_score:
+              type: number
+              format: double
+              nullable: true
+              default: null
+              description: Average expected score when the response is just selected randomly.
+            response_analysis_by_variant:
+              type: boolean
+              default: false
+              description: If true, the LMS should break down the stats and response analysis by the question variant.
+            subquestions:
+              type: array
+              default: [ ]
+              description: Listing of subquestions if the question consists of subquestions.
+              items:
+                type: object
+                properties:
+                  subquestion_id:
+                    type: string
+                    maxLength: 30
+                  score_max:
+                    type: number
+                    format: double
+                    nullable: true
+                    description: Maximum score. May be null if no score can be assigned directly to this
+                      specific subquestion.
+                  response_classes:
+                    type: array
+                    nullable: true
+                    description: All the possible types of responses per subquestion. This is used for
+                      statistics in order to classify responses. Can be null if question does not
+                      support a response analysis.
+                    items:
+                      type: object
+                      properties:
+                        response_class:
+                          type: string
+                          maxLength: 30
+                        score:
+                          type: number
+                          format: double
+                      required: [ response_class, score ]
+                required: [ subquestion_id, score_max, response_classes ]
+          required: [ scoring_method ]
 
     QuestionCreated:
       allOf:
@@ -803,119 +787,123 @@ components:
           required: [ variant ]
 
     Attempt:
-      type: object
-      properties:
-        variant:
-          type: integer
-          minimum: 1
-          description: Which variant of this question, between 1 and question.num_variants.
-        question_summary:
-          type: string
-          nullable: true
-          default: null
-          description: Plain-text summary of the question.
-        right_answer_summary:
-          type: string
-          nullable: true
-          default: null
-          description: Plain-text summary of the right answer.
-        ui:
-          type: object
+      allOf:
+        - $ref: "#/components/schemas/Localized"
+        - type: object
           properties:
-            fields:
-              type: array
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                  type:
-                    type: string
-                    description: Type of the input field.
-                  default:
-                    type: string
-                    nullable: true
-                  validation_regex:
-                    type: string
-                    nullable: true
-                    description: Validate response with this regex. If the response does not match, the response might not be scorable.
-                  required:
-                    type: boolean
-                    description: This field is required. Otherwise the response will not be scorable.
-                  correct_response:
-                    type: string
-                    nullable: true
-                required: [ name, type, default, validation_regex, required, correct_response ]
-            text:
+            variant:
+              type: integer
+              minimum: 1
+              description: Which variant of this question, between 1 and question.num_variants.
+            question_summary:
               type: string
-              format: text/html
-              description: Answer input area
-              example: '<label>Enter your answer: <input type="text"/></label>'
-            css_files:
-              type: array
-              description: List of `qpy://` or `https://` URIs leading CSS files needed by the attempt.
-              items:
-                type: string
-                format: uri
-            javascript_calls:
-              type: array
-              default: [ ]
-              items:
-                type: object
-                properties:
-                  module:
+              nullable: true
+              default: null
+              description: Plain-text summary of the question.
+            ui:
+              type: object
+              properties:
+                formulation:
+                  type: string
+                  format: xhtml
+                  description: XHTML markup of the formulation part of the question.
+                general_feedback:
+                  type: string
+                  format: xhtml
+                  nullable: true
+                  default: null
+                  description: XHTML markup of the general feedback part of the question.
+                specific_feedback:
+                  type: string
+                  format: xhtml
+                  nullable: true
+                  default: null
+                  description: XHTML markup of the response-specific feedback part of the question.
+                right_answer:
+                  type: string
+                  format: xhtml
+                  nullable: true
+                  default: null
+                  description: XHTML markup of the part of the question which explains the correct answer.
+                placeholders:
+                  type: object
+                  default: { }
+                  additionalProperties:
                     type: string
-                    pattern: '^[a-zA-Z0-9_$/@.]+$'
-                    description: JS module name like @[package namespace]/[package short name]/[module].js
-                  function:
+                  description: Names and values of the ``<?p`` placeholders that appear in content.
+                css_files:
+                  type: array
+                  description: List of `qpy://` or `https://` URIs leading CSS files needed by the attempt.
+                  items:
                     type: string
-                    pattern: '^[a-zA-Z0-9_$]+$'
-                    description: Name of a callable value within the JS module.
-                  data:
-                    type: string
-                    nullable: true
-                    description: JSON data given as argument to the function
-                  if_role:
-                    type: string
-                    nullable: true
-                    description: Function is called only if the user has this role.
-                    enum:
-                      - TEACHER
-                      - DEVELOPER
-                      - SCORER
-                      - PROCTOR
-                  if_feedback_type:
-                    type: string
-                    nullable: true
-                    description: Function is called only if the user is allowed to view this type of feedback.
-                    enum:
-                      - SPECIFIC_FEEDBACK
-                      - GENERAL_FEEDBACK
-                      - RIGHT_ANSWER
-                      - HINT
-                required: [ module, function, data, if_role, if_feedback_type ]
-            files:
-              type: array
-              default: [ ]
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                    description: file name
-                  data:
-                    type: string
-                    format: base64
-                    description: file data
-                  mime_type:
-                    type: string
-                    nullable: true
-                required: [ name, data, mime_type ]
-          required: [ fields, text ]
-          readOnly: true
-        package_dependencies:
-          $ref: "#/components/schemas/PackageDependencies"
-      required: [ variant, ui, package_dependencies ]
+                    format: uri
+                javascript_calls:
+                  type: array
+                  default: [ ]
+                  items:
+                    type: object
+                    properties:
+                      module:
+                        type: string
+                        pattern: '^[a-zA-Z0-9_$/@.]+$'
+                        description: JS module name like @[package namespace]/[package short name]/[module].js
+                      function:
+                        type: string
+                        pattern: '^[a-zA-Z0-9_$]+$'
+                        description: Name of a callable value within the JS module.
+                      data:
+                        type: string
+                        nullable: true
+                        description: JSON data given as argument to the function
+                      if_role:
+                        type: string
+                        nullable: true
+                        description: Function is called only if the user has this role.
+                        enum:
+                          - TEACHER
+                          - DEVELOPER
+                          - SCORER
+                          - PROCTOR
+                      if_feedback_type:
+                        type: string
+                        nullable: true
+                        description: Function is called only if the user is allowed to view this type of feedback.
+                        enum:
+                          - SPECIFIC_FEEDBACK
+                          - GENERAL_FEEDBACK
+                          - RIGHT_ANSWER
+                          - HINT
+                    required: [ module, function, data, if_role, if_feedback_type ]
+                files:
+                  type: array
+                  default: [ ]
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        description: file name
+                      mime_type:
+                        type: string
+                        nullable: true
+                        default: null
+                      data:
+                        type: string
+                        format: base64
+                        description: file data
+                    required: [ name, data ]
+                cache_control:
+                  type: string
+                  enum:
+                    - SHARED_CACHE
+                    - PRIVATE_CACHE
+                    - NO_CACHE
+                  default: PRIVATE_CACHE
+              required: [ formulation ]
+              readOnly: true
+            package_dependencies:
+              $ref: "#/components/schemas/PackageDependencies"
+          required: [ variant, ui, package_dependencies ]
 
     AttemptStarted:
       allOf:
@@ -942,20 +930,24 @@ components:
             scoring_state:
               type: string
               nullable: true
+              default: null
               description: Arbitrary values set by the question package code (has to be passed
                 when the attempt was already scored).
             response:
               type: object
               nullable: true
+              default: null
               description: Data from the question's input fields.
-          required: [ attempt_ref, attempt_state, response_ref, scoring_state, response ]
+          required: [ attempt_ref, attempt_state, response_ref ]
 
     AttemptScoreArguments:
       allOf:
-        - $ref: "#/components/schemas/RequestBaseData"
         - $ref: "#/components/schemas/AttemptViewArguments"
         - type: object
           properties:
+            response:
+              type: object
+              additionalProperties: true
             timeout:
               type: number
               minimum: 0
@@ -971,7 +963,7 @@ components:
             generate_hint:
               type: boolean
               description: Try to give a hint on how to improve the response.
-          required: [ timeout, try_scoring_with_countback, generate_hint ]
+          required: [ response, timeout, try_scoring_with_countback, generate_hint ]
 
     AttemptScored:
       allOf:
@@ -980,6 +972,7 @@ components:
             scoring_state:
               type: string
               nullable: true
+              default: null
               description: Arbitrary values set by the question package code (LMS must store this data unmodified).
             scoring_code:
               type: string
@@ -990,16 +983,61 @@ components:
                 - INVALID_RESPONSE
             score:
               type: number
-              nullable: true
               format: double
+              nullable: true
               description: The score for this question attempt, must lie between the `score_min` and `score_max` set by
                 the question.
-            specific_feedback:
-              type: string
+            score_final:
+              type: number
+              format: double
               nullable: true
-              default: null
-              description: Might be null when there is no specific feedback or the specific feedback is shown inline
-                within the question text.
+            scored_inputs:
+              type: object
+              default: { }
+              properties:
+                state:
+                  type: string
+                  enum:
+                    - CORRECT
+                    - CONSEQUENTIAL_SCORE
+                    - PARTIALLY_CORRECT
+                    - WRONG
+                score:
+                  type: number
+                  format: double
+                  nullable: true
+                  default: null
+              required: [ state ]
+              description: Maps input names to their individual scores.
+            scored_subquestions:
+              type: object
+              default: { }
+              properties:
+                score:
+                  type: number
+                  format: double
+                  nullable: true
+                  default: null
+                score_final:
+                  type: number
+                  format: double
+                  nullable: true
+                  default: null
+                scoring_code:
+                  type: string
+                  enum:
+                    - AUTOMATICALLY_SCORED
+                    - NEEDS_MANUAL_SCORING
+                    - RESPONSE_NOT_SCORABLE
+                    - INVALID_RESPONSE
+                  nullable: true
+                  default: null
+                response_summary:
+                  type: string
+                response_class:
+                  type: string
+              description: Maps subquestion IDs to their individual score.
+              required: [ response_summary, response_class ]
             hint:
               type: string
               nullable: true
@@ -1039,31 +1077,7 @@ components:
                     type: number
                     format: double
                 required: [ subquestion_id, response_class, response, score ]
-            scored_fields:
-              type: array
-              nullable: true
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                  correct:
-                    type: boolean
-                    nullable: true
-                  score:
-                    type: number
-                    format: double
-                    nullable: true
-                  max_score:
-                    type: number
-                    format: double
-                    nullable: true
-                  feedback:
-                    type: string
-                    nullable: true
-                required: [ name, correct, score, max_score, feedback ]
-              description: Give specific feedback
-          required: [ scoring_state, scoring_code, score ]
+          required: [ scoring_code, score ]
         - $ref: "#/components/schemas/Attempt"
 
     PackageDependencies:
@@ -1126,6 +1140,7 @@ components:
             - INVALID_QUESTION_STATE
             - INVALID_PACKAGE
             - INVALID_REQUEST
+            - INVALID_OPTIONS_FORM
             - PACKAGE_ERROR
             - PACKAGE_NOT_FOUND
             - CALLBACK_API_ERROR
@@ -1138,6 +1153,7 @@ components:
             * `INVALID_QUESTION_STATE` - Invalid question state.
             * `INVALID_PACKAGE` - The package file is corrupt, the manifest is invalid or there is a checksum mismatch.
             * `INVALID_REQUEST` - Invalid request body.
+            * `INVALID_OPTIONS_FORM` - Invalid form data was provided.
             * `PACKAGE_ERROR` - An error occurred within the package.
             * `PACKAGE_NOT_FOUND` - The package was not found.
             * `CALLBACK_API_ERROR` - An error occurred while contacting the LMS Callback API.
@@ -1149,7 +1165,7 @@ components:
           type: string
           nullable: true
           default: null
-          description: Optional human-readable reason for the error.
+          description: Human-readable reason why the error occurred.
       required: [ error_code, temporary ]
 
     OptionsFormValidationError:
@@ -1159,6 +1175,8 @@ components:
           properties:
             errors:
               type: object
+              additionalProperties:
+                type: string
 
     QuestionStateMigrationError:
       type: object
@@ -1300,6 +1318,27 @@ components:
           $ref: "#/components/schemas/FormHelp"
       required: [ kind, label, name ]
 
+    TextAreaElement:
+      type: object
+      properties:
+        kind:
+          type: string
+          enum: [ textarea ]
+        required:
+          type: boolean
+          default: false
+        default:
+          type: string
+          description: The initial value in this element, if any
+          nullable: true
+          default: null
+        placeholder:
+          type: string
+          description: Text to show while no value is entered
+          nullable: true
+          default: null
+      required: [ kind ]
+
     CheckboxElement:
       type: object
       properties:
@@ -1391,6 +1430,9 @@ components:
           $ref: "#/components/schemas/FormLabel"
         name:
           $ref: "#/components/schemas/FormName"
+        multiple:
+          type: boolean
+          default: false
         options:
           type: array
           items:
@@ -1406,9 +1448,6 @@ components:
                 default: false
             required: [ label, value ]
           minItems: 1
-        multiple:
-          type: boolean
-          default: false
         required:
           type: boolean
           default: false
@@ -1461,7 +1500,7 @@ components:
         elements:
           type: array
           items:
-            $ref: "#/components/schemas/FormElement"
+            $ref: "#/components/schemas/LeafFormElement"
           minItems: 1
         disable_if:
           type: array
@@ -1486,10 +1525,10 @@ components:
           enum: [ repetition ]
         name:
           $ref: "#/components/schemas/FormName"
-        initial_elements:
+        initial_repetitions:
           type: integer
           description: Number of repetitions to show when the form is first loaded
-          minimum: 0
+          minimum: 1
         increment:
           type: integer
           description: Number of repetitions to add with each click of the button
@@ -1503,7 +1542,12 @@ components:
           type: array
           description: Elements to repeat
           items:
-            $ref: "#/components/schemas/FormElement"
+            oneOf:
+              - $ref: "#/components/schemas/LeafFormElement"
+              - $ref: "#/components/schemas/RadioGroupElement"
+              - $ref: "#/components/schemas/GroupElement"
+            discriminator:
+              propertyName: kind
           minItems: 1
       required: [ kind, name, initial_elements, increment, elements ]
 
@@ -1518,17 +1562,32 @@ components:
           $ref: "#/components/schemas/FormName"
       required: [ kind, name ]
 
-    FormElement:
+    LeafFormElement:
       oneOf:
+        - $ref: "#/components/schemas/CheckboxElement"
+        - $ref: "#/components/schemas/HiddenElement"
+        - $ref: "#/components/schemas/GeneratedIdElement"
+        - $ref: "#/components/schemas/SelectElement"
         - $ref: "#/components/schemas/StaticTextElement"
         - $ref: "#/components/schemas/TextInputElement"
-        - $ref: "#/components/schemas/CheckboxElement"
-        - $ref: "#/components/schemas/RadioGroupElement"
-        - $ref: "#/components/schemas/SelectElement"
-        - $ref: "#/components/schemas/HiddenElement"
+        - $ref: "#/components/schemas/TextAreaElement"
+      discriminator:
+        propertyName: kind
+
+    ContainerFormElement:
+      oneOf:
         - $ref: "#/components/schemas/GroupElement"
+        - $ref: "#/components/schemas/RadioGroupElement"
         - $ref: "#/components/schemas/RepetitionElement"
-        - $ref: "#/components/schemas/GeneratedIdElement"
+      discriminator:
+        propertyName: kind
+
+    FormElement:
+      oneOf:
+        - $ref: "#/components/schemas/LeafFormElement"
+        - $ref: "#/components/schemas/ContainerFormElement"
+      discriminator:
+        propertyName: kind
 
     FormSection:
       type: object
@@ -1548,7 +1607,7 @@ components:
       properties:
         name:
           type: string
-          example: questionpy-server
+          default: "questionpy-server"
         version:
           type: string
           format: semver
@@ -1563,10 +1622,11 @@ components:
           description: Maximum package size (in bytes)
         usage:
           $ref: "#/components/schemas/Usage"
-      required: [name, version, allow_lms_packages, max_package_size]
+      required: [ version, allow_lms_packages, max_package_size ]
 
     Usage:
       type: object
+      nullable: true
       description: Current usage of request handlers
       properties:
         requests_in_process:
@@ -1575,7 +1635,13 @@ components:
         requests_in_queue:
           type: integer
           description: Amount of requests waiting to be processed
-      required: [requests_in_process, requests_in_queue]
+      required: [ requests_in_process, requests_in_queue ]
+
+    Localized:
+      type: object
+      properties:
+        lang:
+          type: string
 
 security:
   - BasicAuth: []

--- a/questionpy_common/api/attempt.py
+++ b/questionpy_common/api/attempt.py
@@ -68,13 +68,13 @@ class AttemptFile(BaseModel):
 
 class AttemptUi(BaseModel):
     formulation: str
-    """X(H)ML markup of the formulation part of the question."""
+    """XHTML markup of the formulation part of the question."""
     general_feedback: str | None = None
-    """X(H)ML markup of the general feedback part of the question."""
+    """XHTML markup of the general feedback part of the question."""
     specific_feedback: str | None = None
-    """X(H)ML markup of the response-specific feedback part of the question."""
+    """XHTML markup of the response-specific feedback part of the question."""
     right_answer: str | None = None
-    """X(H)ML markup of the part of the question which explains the correct answer."""
+    """XHTML markup of the part of the question which explains the correct answer."""
 
     placeholders: dict[str, str] = {}
     """Names and values of the ``<?p`` placeholders that appear in content."""

--- a/questionpy_server/models.py
+++ b/questionpy_server/models.py
@@ -20,13 +20,13 @@ class PackageInfo(BaseModel):
     namespace: str
     name: dict[Bcp47LanguageTag, str]
     type: PackageType
-    author: str | None
+    author: str
     url: str | None
-    languages: list[Bcp47LanguageTag] | None
+    languages: list[Bcp47LanguageTag] = Field(min_length=1)
     description: dict[Bcp47LanguageTag, str] | None
     icon: str | None
     license: str | None
-    tags: set[str] | None
+    tags: set[str] = set()
 
 
 class PackageVersionSpecificInfo(BaseModel):
@@ -78,10 +78,6 @@ class QuestionCreateArguments(RequestBaseData):
     form_data: dict[str, object]
 
 
-class QuestionViewArguments(RequestBaseData):
-    question_state: str
-
-
 class QuestionCreated(QuestionModel):
     question_state: str
 
@@ -98,7 +94,6 @@ class AttemptViewArguments(RequestBaseData):
 
 class AttemptScoreArguments(AttemptViewArguments):
     response: dict[str, Any]
-    responses: list[dict[str, object]] | None = None
     generate_hint: bool
 
 


### PR DESCRIPTION
Um das Reviewen etwas zu erleichtern, habe ich den PR in zehn Commits unterteilt.

#### Properties, die in der QPPE, aber nicht in den `BaseModel`s zu finden sind
Die `*_ref`-Properties lasse ich hierbei außen vor.

##### Question:
- `num_subquestions`
- `render_every_view`

##### Attempt
- `question_summary`

##### AttemptScoreArguments
- `timeout`
- `try_scoring_with_countback`

##### AttemptScored
- `hint`
- `more_hints_available`


#### Unbenutze Models
- `QuestionViewArguments` (mit diesem PR entfernt)
- `QuestionStateMigrationError`

#### Ausblick (und nicht Teil dieses PRs)
1. Angleichung der Quotes (es werden Single- und Double-Quotes verwendet)
2. Die Form-Elemente könnten per [Model Composition](https://swagger.io/docs/specification/v3_0/data-models/inheritance-and-polymorphism/) etwas kürzer dargestellt werden.
3. Eventuell die `QPPE` in weitere `.yaml`-Dateien aufteilen.