### PR TITLE
chore(ci): lint QPPE with Spectral

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,22 @@ on:
       - opened
 
 jobs:
-  ci:
-    # https://github.com/questionpy-org/.github
+  python:
     uses: questionpy-org/.github/.github/workflows/python-ci.yml@v10
     with:
       # GitHub workflow inputs do not support lists, so we pass JSON.
       pytest-python-versions: '["3.12", "3.13"]'
       packages: questionpy_common questionpy_server tests
+
+  lint-qppe:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+
+      - name: Lint QPPE
+        working-directory: ./docs
+        run: npx @stoplight/spectral-cli lint -f stylish -f text -o.stylish "<stdout>" -o.text "$GITHUB_STEP_SUMMARY" qppe-lms.yaml qppe-server.yaml

--- a/docs/lint.sh
+++ b/docs/lint.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-set -o errexit
-
-cd "$(dirname "$0")"
-exec npx "@stoplight/spectral-cli@^6.15.0" lint qppe-server.yaml qppe-lms.yaml


### PR DESCRIPTION
Basiert auf #156 

Mit diesem PR wird ein neuer CI-Job hinzugefügt, welcher mit [Spectral](https://github.com/stoplightio/spectral) (bzw. [Spectral Linter Action](https://github.com/stoplightio/spectral-action)) die `qppe-lms.yaml` und `qppe-server.yaml` linted.

[Hier](https://github.com/questionpy-org/questionpy-server/actions/runs/15849508615/job/44679298649) könnt ihr euch mal ansehen, wie das ganze aussieht, wenn es zu Fehlermeldungen/Warnungen kommt. Mir gefällt es nicht, dass zwei Jobs aufgelistet werden: `lint-qppe` und `Lint (push)`.

Ich habe die`lint.sh` wieder entfernt, da das eher ins [qpy-dev](https://github.com/questionpy-org/qpy-dev)-Repo passt.