### PR TITLE
Statische Dependencies Laden

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "questionpy-server"
 description = "QuestionPy application server"
 license = { file = "LICENSE.md" }
 urls = { homepage = "https://questionpy.org" }
-version = "0.7.0"
+version = "0.8.0"
 authors = [
     { name = "TU Berlin innoCampus" },
     { email = "info@isis.tu-berlin.de" }

--- a/questionpy_common/constants.py
+++ b/questionpy_common/constants.py
@@ -17,3 +17,5 @@ MAX_QUESTION_STATE_SIZE: Final[ByteSize] = ByteSize(2 * MiB)
 
 MANIFEST_FILENAME = "qpy_manifest.json"
 DIST_DIR = "dist"
+
+MAX_QPY_DEPENDENCY_LEVELS = 5

--- a/questionpy_common/environment.py
+++ b/questionpy_common/environment.py
@@ -1,7 +1,6 @@
 #  This file is part of QuestionPy. (https://questionpy.org)
 #  QuestionPy is free software released under terms of the MIT license. See LICENSE.md.
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
-from abc import abstractmethod
 from collections.abc import Callable, Mapping, Sequence
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -104,35 +103,43 @@ type OnRequestCallback = Callable[[RequestUser], None]
 
 
 class Environment(Protocol):
-    type: str
-    """The kind of worker we are running in.
+    @property
+    def type(self) -> str:
+        """The kind of worker we are running in.
 
-    The well-known values are:
+        The well-known values are:
 
-    - process: The worker is running in a subprocess of the server process.
-    - thread: The worker is running in a thread of the server process. Should only be used for debugging since it is
-      not possible to isolate workers effectively.
-    - container: The worker is sandboxed in a Docker(-like) container.
+        - process: The worker is running in a subprocess of the server process.
+        - thread: The worker is running in a thread of the server process. Should only be used for debugging since it is
+          not possible to isolate workers effectively.
+        - container: The worker is sandboxed in a Docker(-like) container.
 
-    Other worker types may be added in future. (Hence the `str` type.)
-    """
-    limits: WorkerResourceLimits | None
-    """The resource limits imposed on the worker, if any."""
-    request_user: RequestUser | None
-    """If the worker is currently processing a request, information about the user that it is being processed for.
+        Other worker types may be added in the future. (Hence the `str` type.)
+        """
 
-    When no request is being processed (such as during a call to the package's `init` function), this will be None.
-    """
-    main_package: Package | None
-    """The main package in this worker, if one is loaded yet."""
-    packages: Mapping[PackageNamespaceAndShortName, Package]
-    """All packages loaded in the worker, including the main package.
+    @property
+    def limits(self) -> WorkerResourceLimits | None:
+        """The resource limits imposed on the worker, if any."""
 
-    Keys are the package namespace and short name. Only one version of a package can be loaded at a time. This may
-    include packages which are not yet initialized (i.e. their `init` function has not finished yet).
-    """
+    @property
+    def request_user(self) -> RequestUser | None:
+        """If the worker is currently processing a request, information about the user that it is being processed for.
 
-    @abstractmethod
+        When no request is being processed (such as during a call to the package's `init` function), this will be None.
+        """
+
+    @property
+    def main_package(self) -> Package:
+        """The main package in this worker."""
+
+    @property
+    def packages(self) -> Mapping[PackageNamespaceAndShortName, Package]:
+        """All packages loaded in the worker, including the main package.
+
+        Keys are the package namespace and short name. Only one version of a package can be loaded at a time. This may
+        include packages which are not yet initialized (i.e. their `init` function has not finished yet).
+        """
+
     def register_on_request_callback(self, callback: OnRequestCallback) -> None:
         """Register a new on-request callback.
 

--- a/questionpy_common/environment.py
+++ b/questionpy_common/environment.py
@@ -10,7 +10,6 @@ from importlib.resources.abc import Traversable
 from typing import NamedTuple, Protocol
 
 from questionpy_common.api.package import QPyPackageInterface
-from questionpy_common.api.qtype import QuestionTypeInterface
 from questionpy_common.manifest import Bcp47LanguageTag, Manifest
 
 __all__ = [
@@ -152,7 +151,7 @@ class Environment(Protocol):
 type PackageInitFunction = (
     Callable[[Package, Environment], QPyPackageInterface]
     | Callable[[Package], QPyPackageInterface]
-    | Callable[[], QuestionTypeInterface]
+    | Callable[[], QPyPackageInterface]
 )
 """Signature of the "init"-function expected in the main package."""
 

--- a/questionpy_common/environment.py
+++ b/questionpy_common/environment.py
@@ -21,6 +21,8 @@ __all__ = [
     "Package",
     "PackageInitFunction",
     "PackageNamespaceAndShortName",
+    "PackageNotInitializedError",
+    "PackageNotLoadedError",
     "PackageState",
     "RequestUser",
     "WorkerResourceLimits",
@@ -46,7 +48,7 @@ class WorkerResourceLimits:
 
 @total_ordering
 class PackageState(Enum):
-    PREPARED = 1
+    OPENED = 1
     """The package is present and in the process of being loaded, but none of its code has been executed yet."""
     LOADED = 2
     """The package entrypoint has been imported."""
@@ -57,6 +59,16 @@ class PackageState(Enum):
         if isinstance(other, PackageState):
             return self.value < other.value
         return NotImplemented
+
+
+class PackageNamespaceAndShortName(NamedTuple):
+    """Tuple of namespace and short name, identifying any version of a specific package."""
+
+    namespace: str
+    short_name: str
+
+    def __str__(self) -> str:
+        return f"@{self.namespace}/{self.short_name}"
 
 
 class Package(Protocol):
@@ -75,15 +87,20 @@ class Package(Protocol):
     @property
     def state(self) -> PackageState: ...
 
+    @property
+    def interface(self) -> QPyPackageInterface:
+        """Gives access to the package's outward interface.
+
+        Raises:
+            PackageNotInitializedError
+        """
+
+    @property
+    def dependencies(self) -> Mapping[PackageNamespaceAndShortName, "Package"]:
+        """The direct QPy dependencies of this package."""
+
 
 type OnRequestCallback = Callable[[RequestUser], None]
-
-
-class PackageNamespaceAndShortName(NamedTuple):
-    """Tuple of namespace and short name, identifying any version of a specific package."""
-
-    namespace: str
-    short_name: str
 
 
 class Environment(Protocol):
@@ -106,8 +123,8 @@ class Environment(Protocol):
 
     When no request is being processed (such as during a call to the package's `init` function), this will be None.
     """
-    main_package: Package
-    """The main package whose entrypoint was called."""
+    main_package: Package | None
+    """The main package in this worker, if one is loaded yet."""
     packages: Mapping[PackageNamespaceAndShortName, Package]
     """All packages loaded in the worker, including the main package.
 
@@ -155,3 +172,11 @@ def set_qpy_environment(env: Environment | None) -> None:
 
 class NoEnvironmentError(Exception):
     pass
+
+
+class PackageNotInitializedError(Exception):
+    """The packages state was not INITIALIZED."""
+
+
+class PackageNotLoadedError(Exception):
+    """The packages state was not LOADED or higher."""

--- a/questionpy_common/environment.py
+++ b/questionpy_common/environment.py
@@ -181,8 +181,8 @@ class NoEnvironmentError(Exception):
 
 
 class PackageNotInitializedError(Exception):
-    """The packages state was not INITIALIZED."""
+    """The package's state was not INITIALIZED."""
 
 
 class PackageNotLoadedError(Exception):
-    """The packages state was not LOADED or higher."""
+    """The package's state was not LOADED or higher."""

--- a/questionpy_common/manifest.py
+++ b/questionpy_common/manifest.py
@@ -123,8 +123,10 @@ class PackageFile(BaseModel):
 
 
 class DistStaticQPyDependency(BaseModel):
-    name: str
+    dir_name: str
+    """Name (without `dist/dependencies/qpy/`) of the directory the dependency package contents reside in."""
     hash: str
+    """Hash of the ZIP package whose contents lie in `dir_name`."""
 
 
 type DistQPyDependency = DistStaticQPyDependency

--- a/questionpy_common/manifest.py
+++ b/questionpy_common/manifest.py
@@ -122,6 +122,18 @@ class PackageFile(BaseModel):
     size: int
 
 
+class DistStaticQPyDependency(BaseModel):
+    name: str
+    hash: str
+
+
+type DistQPyDependency = DistStaticQPyDependency
+
+
+class DistDependencies(BaseModel):
+    qpy: list[DistQPyDependency] = []
+
+
 class Manifest(SourceManifest):
     """Represents a package manifest.
 
@@ -129,3 +141,5 @@ class Manifest(SourceManifest):
     """
 
     static_files: dict[str, PackageFile] = {}
+
+    dependencies: DistDependencies = DistDependencies()

--- a/questionpy_server/hash.py
+++ b/questionpy_server/hash.py
@@ -1,31 +1,26 @@
 #  This file is part of the QuestionPy Server. (https://questionpy.org)
 #  The QuestionPy Server is free software released under terms of the MIT license. See LICENSE.md.
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
-
-from hashlib import sha256
+from hashlib import file_digest, sha256
+from io import BufferedIOBase, RawIOBase
 from pathlib import Path
 from typing import NamedTuple
 
-from questionpy_common.constants import MiB
 
-
-def calculate_hash(source: bytes | Path) -> str:
+def calculate_hash(source: bytes | Path | RawIOBase | BufferedIOBase) -> str:
     """Calculates the sha256 of either bytes or a file.
 
     Args:
-        source (Union[bytes, Path]) : bytes or path to file
-
-    Returns:
-        str: the sha256
+        source: bytes, already opened file, or path to a file
     """
-    sha = sha256()
-
     if isinstance(source, bytes):
+        sha = sha256()
         sha.update(source)
-    else:
+    elif isinstance(source, Path):
         with source.open("rb") as file:
-            while chunk := file.read(5 * MiB):
-                sha.update(chunk)
+            sha = file_digest(file, sha256)
+    else:
+        sha = file_digest(source, sha256)
 
     return sha.hexdigest()
 

--- a/questionpy_server/worker/impl/_base.py
+++ b/questionpy_server/worker/impl/_base.py
@@ -107,10 +107,17 @@ class BaseWorker(Worker, ABC):
                 LoadQPyPackage.Response,
                 self._load_qpy_package_timeout,
             )
-            package_hash = self.package.hash if isinstance(self.package, ZipPackageLocation) else None
-            self.loaded_packages.append(
-                LoadedPackage(namespace=loaded.nssn.namespace, short_name=loaded.nssn.short_name, hash=package_hash)
-            )
+
+            main_package_hash = self.package.hash if isinstance(self.package, ZipPackageLocation) else None
+            for newly_loaded_nssn in loaded.loaded_packages:
+                loaded_package = LoadedPackage(
+                    namespace=newly_loaded_nssn.namespace,
+                    short_name=newly_loaded_nssn.short_name,
+                    hash=main_package_hash if newly_loaded_nssn == loaded.root_nssn else None,
+                )
+
+                self.loaded_packages.append(loaded_package)
+
         except BaseWorkerError as e:
             await self.stop(3)
             msg = "Worker has exited before or during initialization."

--- a/questionpy_server/worker/impl/_base.py
+++ b/questionpy_server/worker/impl/_base.py
@@ -48,6 +48,7 @@ from questionpy_server.worker.runtime.messages import (
 from questionpy_server.worker.runtime.package_location import (
     DirPackageLocation,
     FunctionPackageLocation,
+    PackageLocation,
     ZipPackageLocation,
 )
 
@@ -102,26 +103,29 @@ class BaseWorker(Worker, ABC):
                 InitWorker.Response,
                 self._init_worker_timeout,
             )
-            loaded = await self.send_and_wait_for_response(
-                LoadQPyPackage(location=self.package, main=True),
-                LoadQPyPackage.Response,
-                self._load_qpy_package_timeout,
-            )
 
-            main_package_hash = self.package.hash if isinstance(self.package, ZipPackageLocation) else None
-            for newly_loaded_nssn in loaded.loaded_packages:
-                loaded_package = LoadedPackage(
-                    namespace=newly_loaded_nssn.namespace,
-                    short_name=newly_loaded_nssn.short_name,
-                    hash=main_package_hash if newly_loaded_nssn == loaded.root_nssn else None,
-                )
-
-                self.loaded_packages.append(loaded_package)
-
+            await self._load_package(self.package, main=True)
         except BaseWorkerError as e:
             await self.stop(3)
             msg = "Worker has exited before or during initialization."
             raise WorkerStartError(msg, temporary=e.temporary, worker_name=self.name) from e
+
+    async def _load_package(self, package_location: PackageLocation, *, main: bool) -> None:
+        loaded = await self.send_and_wait_for_response(
+            LoadQPyPackage(location=package_location, main=main),
+            LoadQPyPackage.Response,
+            self._load_qpy_package_timeout,
+        )
+
+        root_package_hash = package_location.hash if isinstance(package_location, ZipPackageLocation) else None
+        for newly_loaded_nssn in loaded.loaded_packages:
+            loaded_package = LoadedPackage(
+                namespace=newly_loaded_nssn.namespace,
+                short_name=newly_loaded_nssn.short_name,
+                hash=root_package_hash if newly_loaded_nssn == loaded.root_nssn else None,
+            )
+
+            self.loaded_packages.append(loaded_package)
 
     def send(self, message: MessageToWorker) -> None:
         if self._connection is None or self._observe_task is None or self._observe_task.done():

--- a/questionpy_server/worker/runtime/manager.py
+++ b/questionpy_server/worker/runtime/manager.py
@@ -176,7 +176,9 @@ class WorkerManager:
             raise CircularDependencyError(nssn, stack)
 
         if nssn in self._packages:
-            # For now, we don't support two packages using the same version of a static dependency.
+            # For now, we don't support two packages using the same static dependency, even if they would use the same
+            # version. Supporting the latter case would require us to either trust or check that both dependency's
+            # content is identical.
             err_msg = f"Package '{nssn}' is already loaded. Dependency stack: {stack}"
             raise DependencyError(err_msg, stack)
 

--- a/questionpy_server/worker/runtime/manager.py
+++ b/questionpy_server/worker/runtime/manager.py
@@ -3,9 +3,10 @@
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
 import dataclasses
 import resource
-from collections.abc import Callable, Generator, Mapping
+from collections.abc import Callable, Generator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
+from graphlib import TopologicalSorter
 from types import MappingProxyType
 from typing import TYPE_CHECKING, NoReturn, TypeVar, cast
 
@@ -15,10 +16,12 @@ from questionpy_common.environment import (
     OnRequestCallback,
     Package,
     PackageNamespaceAndShortName,
+    PackageState,
     RequestUser,
     WorkerResourceLimits,
     set_qpy_environment,
 )
+from questionpy_common.manifest import PackageType
 from questionpy_server.worker.runtime.connection import WorkerToServerConnection
 from questionpy_server.worker.runtime.messages import (
     CreateQuestionFromOptions,
@@ -84,6 +87,16 @@ class EnvironmentImpl(Environment):
 
 M = TypeVar("M", bound=MessageToWorker)
 type OnMessageCallback[M: MessageToWorker] = Callable[[M], MessageToServer]
+
+
+def _linearize_packages(
+    packages: Mapping[PackageNamespaceAndShortName, ImportablePackage],
+) -> Sequence[PackageNamespaceAndShortName]:
+    sorter = TopologicalSorter[PackageNamespaceAndShortName]()
+    for nssn, package in packages.items():
+        sorter.add(nssn, *package.dependencies.keys())
+
+    return tuple(sorter.static_order())
 
 
 class WorkerManager:
@@ -175,47 +188,39 @@ class WorkerManager:
 
         return nssn, package
 
-    def _load_and_init_recursively(
-        self,
-        msg: LoadQPyPackage,
-        package: ImportablePackage,
-        *,
-        as_main: bool,
-    ) -> None:
-        if not self._env or not self._worker_home:
-            self._raise_not_initialized(msg)
-
-        for dep in package.dependencies.values():
-            self._load_and_init_recursively(msg, dep, as_main=False)
-
-        package.load()
-        try:
-            package.init(self._env)
-        except NoInitFunctionError:
-            if as_main:
-                # The main package must have an init function.
-                raise
-
     def on_msg_load_qpy_package(self, msg: LoadQPyPackage) -> MessageToServer:
         if not self._env or not self._worker_home:
             self._raise_not_initialized(msg)
 
-        nssn, package = self._open_packages_recursively(msg, msg.location, ())
-        self._load_and_init_recursively(msg, package, as_main=msg.main)
+        root_nssn, root_package = self._open_packages_recursively(msg, msg.location, ())
 
         if msg.main:
-            self._env = dataclasses.replace(self._env, _main_package=package)
+            self._env = dataclasses.replace(self._env, _main_package=root_package)
             set_qpy_environment(self._env)
 
-            self._question_type = cast("QuestionTypeInterface", package.interface)
+        linearized = _linearize_packages(self._packages)
+        for nssn in linearized:
+            package = self._packages[nssn]
+            if package.state < PackageState.LOADED:
+                package.load()
 
-        return LoadQPyPackage.Response(nssn=nssn)
+            if package.state < PackageState.INITIALIZED:
+                is_question_like = package.manifest.type in {PackageType.QUESTION, PackageType.QUESTIONTYPE}
+                try:
+                    package.init(self._env)
+                except NoInitFunctionError:
+                    if is_question_like:
+                        # Questions and question types MUST have init functions. (Others MAY.)
+                        raise
+
+                if package is root_package and msg.main and is_question_like:
+                    self._question_type = cast("QuestionTypeInterface", package.interface)
+
+        return LoadQPyPackage.Response(root_nssn=root_nssn, loaded_packages=linearized)
 
     def on_msg_get_qpy_package_manifest(self, msg: GetQPyPackageManifest) -> MessageToServer:
         if not self._env:
             self._raise_not_initialized(msg)
-        if not self._env.main_package:
-            self._raise_no_main_package_loaded(msg)
 
         return GetQPyPackageManifest.Response(manifest=self._env.main_package.manifest)
 

--- a/questionpy_server/worker/runtime/manager.py
+++ b/questionpy_server/worker/runtime/manager.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, NoReturn, TypeVar, cast
 
+from questionpy_common.constants import MAX_QPY_DEPENDENCY_LEVELS
 from questionpy_common.environment import (
     Environment,
     OnRequestCallback,
@@ -32,7 +33,8 @@ from questionpy_server.worker.runtime.messages import (
     ViewAttempt,
     WorkerError,
 )
-from questionpy_server.worker.runtime.package import ImportablePackage, load_package
+from questionpy_server.worker.runtime.package import ImportablePackage, NoInitFunctionError, open_qpy_package
+from questionpy_server.worker.runtime.package_location import PackageLocation
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -45,9 +47,9 @@ __all__ = ["WorkerManager"]
 @dataclass
 class EnvironmentImpl(Environment):
     type: str
-    main_package: ImportablePackage
     packages: dict[PackageNamespaceAndShortName, ImportablePackage]
     _on_request_callbacks: list[OnRequestCallback]
+    main_package: ImportablePackage | None = None
     request_user: RequestUser | None = None
     limits: WorkerResourceLimits | None = None
 
@@ -63,10 +65,8 @@ class WorkerManager:
     def __init__(self, server_connection: WorkerToServerConnection):
         self._connection = server_connection
 
-        self._worker_type: str | None = None
         self._packages: dict[PackageNamespaceAndShortName, ImportablePackage] = {}
 
-        self._limits: WorkerResourceLimits | None = None
         self._worker_home: Path | None = None
 
         self._env: EnvironmentImpl | None = None
@@ -89,12 +89,19 @@ class WorkerManager:
         if not isinstance(init_msg, InitWorker):
             raise self._raise_not_initialized(init_msg)
 
-        self._worker_type = init_msg.worker_type
         self._worker_home = init_msg.worker_home
-        self._limits = init_msg.limits
-        if self._limits:
+
+        if init_msg.limits:
             # Limit memory usage.
-            resource.setrlimit(resource.RLIMIT_AS, (self._limits.max_memory, self._limits.max_memory))
+            resource.setrlimit(resource.RLIMIT_AS, (init_msg.limits.max_memory, init_msg.limits.max_memory))
+
+        self._env = EnvironmentImpl(
+            type=init_msg.worker_type,
+            limits=init_msg.limits,
+            packages=self._packages,
+            _on_request_callbacks=self._on_request_callbacks,
+        )
+        set_qpy_environment(self._env)
 
         self._connection.send_message(InitWorker.Response())
 
@@ -111,43 +118,82 @@ class WorkerManager:
                 response = WorkerError.from_exception(error, cause=msg)
             self._connection.send_message(response)
 
-    def on_msg_load_qpy_package(self, msg: LoadQPyPackage) -> MessageToServer:
-        if not self._worker_type or not self._worker_home:
+    def _open_packages_recursively(
+        self,
+        msg: LoadQPyPackage,
+        package_location: PackageLocation,
+        stack: tuple[PackageNamespaceAndShortName, ...] = (),
+    ) -> tuple[PackageNamespaceAndShortName, ImportablePackage]:
+        if not self._env or not self._worker_home:
             self._raise_not_initialized(msg)
 
-        package = load_package(msg.location, self._worker_home)
-
+        package = open_qpy_package(package_location, self._worker_home)
         nssn = PackageNamespaceAndShortName(package.manifest.namespace, package.manifest.short_name)
+
+        if nssn in stack and self._packages[nssn].manifest.version == package.manifest.version:
+            raise CircularDependencyError(nssn, stack)
+
+        if nssn in self._packages:
+            # For now, we don't support two packages using the same version of a static dependency.
+            err_msg = f"Package '{nssn}' is already loaded. Dependency stack: {stack}"
+            raise DependencyError(err_msg, stack)
+
         self._packages[nssn] = package
 
-        if msg.main:
-            self._env = EnvironmentImpl(
-                type=self._worker_type,
-                limits=self._limits,
-                packages=self._packages,
-                main_package=package,
-                _on_request_callbacks=self._on_request_callbacks,
-            )
-            set_qpy_environment(self._env)
-        elif not self._env:
-            self._raise_no_main_package_loaded(msg)
+        if len(stack) >= MAX_QPY_DEPENDENCY_LEVELS and package.manifest.dependencies.qpy:
+            raise TooDeeplyNestedDependencyError(stack)
 
-        package.setup_imports()
+        new_stack = (*stack, nssn)
+        for dep_location in package.resolve_static_dependencies():
+            dep_nssn, dep_package = self._open_packages_recursively(msg, dep_location, new_stack)
+            package.dependencies[dep_nssn] = dep_package
 
-        package_interface = package.init(self._env)
+        return nssn, package
+
+    def _load_and_init_recursively(
+        self,
+        msg: LoadQPyPackage,
+        package: ImportablePackage,
+        *,
+        as_main: bool,
+    ) -> None:
+        if not self._env or not self._worker_home:
+            self._raise_not_initialized(msg)
+
+        for dep in package.dependencies.values():
+            self._load_and_init_recursively(msg, dep, as_main=False)
+
+        package.load()
+        try:
+            package.init(self._env)
+        except NoInitFunctionError:
+            if as_main:
+                # The main package must have an init function.
+                raise
+
+    def on_msg_load_qpy_package(self, msg: LoadQPyPackage) -> MessageToServer:
+        if not self._env or not self._worker_home:
+            self._raise_not_initialized(msg)
+
+        nssn, package = self._open_packages_recursively(msg, msg.location, ())
+        self._load_and_init_recursively(msg, package, as_main=msg.main)
+
         if msg.main:
-            self._question_type = cast("QuestionTypeInterface", package_interface)
+            self._env.main_package = package
+            self._question_type = cast("QuestionTypeInterface", package.interface)
 
         return LoadQPyPackage.Response(nssn=nssn)
 
     def on_msg_get_qpy_package_manifest(self, msg: GetQPyPackageManifest) -> MessageToServer:
         if not self._env:
+            self._raise_not_initialized(msg)
+        if not self._env.main_package:
             self._raise_no_main_package_loaded(msg)
 
         return GetQPyPackageManifest.Response(manifest=self._env.main_package.manifest)
 
     def on_msg_get_options_form_definition(self, msg: GetOptionsForm) -> MessageToServer:
-        if not self._worker_type:
+        if not self._env:
             self._raise_not_initialized(msg)
         if not self._question_type:
             self._raise_no_main_package_loaded(msg)
@@ -158,7 +204,7 @@ class WorkerManager:
             return GetOptionsForm.Response(definition=definition, form_data=form_data)
 
     def on_msg_create_question_from_options(self, msg: CreateQuestionFromOptions) -> CreateQuestionFromOptions.Response:
-        if not self._worker_type:
+        if not self._env:
             self._raise_not_initialized(msg)
         if not self._question_type:
             self._raise_no_main_package_loaded(msg)
@@ -171,7 +217,7 @@ class WorkerManager:
             )
 
     def on_msg_start_attempt(self, msg: StartAttempt) -> StartAttempt.Response:
-        if not self._worker_type:
+        if not self._env:
             self._raise_not_initialized(msg)
         if not self._question_type:
             self._raise_no_main_package_loaded(msg)
@@ -182,7 +228,7 @@ class WorkerManager:
             return StartAttempt.Response(attempt_started_model=attempt_started_model)
 
     def on_msg_view_attempt(self, msg: ViewAttempt) -> ViewAttempt.Response:
-        if not self._worker_type:
+        if not self._env:
             self._raise_not_initialized(msg)
         if not self._question_type:
             self._raise_no_main_package_loaded(msg)
@@ -193,7 +239,7 @@ class WorkerManager:
             return ViewAttempt.Response(attempt_model=attempt_model)
 
     def on_msg_score_attempt(self, msg: ScoreAttempt) -> ScoreAttempt.Response:
-        if not self._worker_type:
+        if not self._env:
             self._raise_not_initialized(msg)
         if not self._question_type:
             self._raise_no_main_package_loaded(msg)
@@ -240,3 +286,19 @@ class WorkerNotInitializedError(Exception):
 
 class MainPackageNotLoadedError(Exception):
     pass
+
+
+class DependencyError(Exception):
+    def __init__(self, message: str, stack: tuple[PackageNamespaceAndShortName, ...]) -> None:
+        super().__init__(message)
+        self.stack = stack
+
+
+class CircularDependencyError(DependencyError):
+    def __init__(self, nssn: PackageNamespaceAndShortName, stack: tuple[PackageNamespaceAndShortName, ...]):
+        super().__init__(f"'{nssn}'. Dependency stack: {stack}", stack)
+
+
+class TooDeeplyNestedDependencyError(Exception):
+    def __init__(self, stack: tuple[PackageNamespaceAndShortName, ...]) -> None:
+        super().__init__(f"Dependency graph is deeper than '{MAX_QPY_DEPENDENCY_LEVELS}' levels at '{stack}'.", stack)

--- a/questionpy_server/worker/runtime/manager.py
+++ b/questionpy_server/worker/runtime/manager.py
@@ -7,6 +7,7 @@ from collections.abc import Callable, Generator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from graphlib import TopologicalSorter
+from pathlib import Path
 from types import MappingProxyType
 from typing import TYPE_CHECKING, NoReturn, TypeVar, cast
 
@@ -42,8 +43,6 @@ from questionpy_server.worker.runtime.package import ImportablePackage, NoInitFu
 from questionpy_server.worker.runtime.package_location import PackageLocation
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from questionpy_common.api.qtype import QuestionTypeInterface
 
 __all__ = ["WorkerManager"]
@@ -156,6 +155,11 @@ class WorkerManager:
                 response = WorkerError.from_exception(error, cause=msg)
             self._connection.send_message(response)
 
+    @staticmethod
+    def _open_package(location: PackageLocation, worker_home: Path) -> ImportablePackage:
+        # This is a separate method to allow it to be mocked separately.
+        return open_qpy_package(location, worker_home)
+
     def _open_packages_recursively(
         self,
         msg: LoadQPyPackage,
@@ -165,7 +169,7 @@ class WorkerManager:
         if not self._env or not self._worker_home:
             self._raise_not_initialized(msg)
 
-        package = open_qpy_package(package_location, self._worker_home)
+        package = self._open_package(package_location, self._worker_home)
         nssn = PackageNamespaceAndShortName(package.manifest.namespace, package.manifest.short_name)
 
         if nssn in stack and self._packages[nssn].manifest.version == package.manifest.version:

--- a/questionpy_server/worker/runtime/manager.py
+++ b/questionpy_server/worker/runtime/manager.py
@@ -182,10 +182,11 @@ class WorkerManager:
 
         self._packages[nssn] = package
 
-        if len(stack) >= MAX_QPY_DEPENDENCY_LEVELS and package.manifest.dependencies.qpy:
-            raise TooDeeplyNestedDependencyError(stack)
-
         new_stack = (*stack, nssn)
+
+        if len(stack) >= MAX_QPY_DEPENDENCY_LEVELS and package.manifest.dependencies.qpy:
+            raise TooDeeplyNestedDependencyError(new_stack)
+
         for dep_location in package.resolve_static_dependencies():
             dep_nssn, dep_package = self._open_packages_recursively(msg, dep_location, new_stack)
             package.dependencies[dep_nssn] = dep_package
@@ -339,6 +340,6 @@ class CircularDependencyError(DependencyError):
         super().__init__(f"'{nssn}'. Dependency stack: {stack}", stack)
 
 
-class TooDeeplyNestedDependencyError(Exception):
+class TooDeeplyNestedDependencyError(DependencyError):
     def __init__(self, stack: tuple[PackageNamespaceAndShortName, ...]) -> None:
         super().__init__(f"Dependency graph is deeper than '{MAX_QPY_DEPENDENCY_LEVELS}' levels at '{stack}'.", stack)

--- a/questionpy_server/worker/runtime/manager.py
+++ b/questionpy_server/worker/runtime/manager.py
@@ -1,20 +1,22 @@
 #  This file is part of the QuestionPy Server. (https://questionpy.org)
 #  The QuestionPy Server is free software released under terms of the MIT license. See LICENSE.md.
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+import dataclasses
 import resource
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Generator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import TYPE_CHECKING, NoReturn, TypeVar, cast
 
 from questionpy_common.constants import MAX_QPY_DEPENDENCY_LEVELS
 from questionpy_common.environment import (
     Environment,
     OnRequestCallback,
+    Package,
     PackageNamespaceAndShortName,
     RequestUser,
     WorkerResourceLimits,
-    get_qpy_environment,
     set_qpy_environment,
 )
 from questionpy_server.worker.runtime.connection import WorkerToServerConnection
@@ -44,14 +46,37 @@ if TYPE_CHECKING:
 __all__ = ["WorkerManager"]
 
 
-@dataclass
+@dataclass(frozen=True)
 class EnvironmentImpl(Environment):
-    type: str
-    packages: dict[PackageNamespaceAndShortName, ImportablePackage]
+    _type: str
+    _packages: dict[PackageNamespaceAndShortName, ImportablePackage]
     _on_request_callbacks: list[OnRequestCallback]
-    main_package: ImportablePackage | None = None
-    request_user: RequestUser | None = None
-    limits: WorkerResourceLimits | None = None
+    _main_package: ImportablePackage | None = None
+    _request_user: RequestUser | None = None
+    _limits: WorkerResourceLimits | None = None
+
+    @property
+    def type(self) -> str:
+        return self._type
+
+    @property
+    def packages(self) -> Mapping[PackageNamespaceAndShortName, Package]:
+        return MappingProxyType(self._packages)
+
+    @property
+    def main_package(self) -> Package:
+        if not self._main_package:
+            raise MainPackageNotLoadedError
+
+        return self._main_package
+
+    @property
+    def request_user(self) -> RequestUser | None:
+        return self._request_user
+
+    @property
+    def limits(self) -> WorkerResourceLimits | None:
+        return self._limits
 
     def register_on_request_callback(self, callback: OnRequestCallback) -> None:
         self._on_request_callbacks.append(callback)
@@ -96,9 +121,9 @@ class WorkerManager:
             resource.setrlimit(resource.RLIMIT_AS, (init_msg.limits.max_memory, init_msg.limits.max_memory))
 
         self._env = EnvironmentImpl(
-            type=init_msg.worker_type,
-            limits=init_msg.limits,
-            packages=self._packages,
+            _type=init_msg.worker_type,
+            _limits=init_msg.limits,
+            _packages=self._packages,
             _on_request_callbacks=self._on_request_callbacks,
         )
         set_qpy_environment(self._env)
@@ -179,7 +204,9 @@ class WorkerManager:
         self._load_and_init_recursively(msg, package, as_main=msg.main)
 
         if msg.main:
-            self._env.main_package = package
+            self._env = dataclasses.replace(self._env, _main_package=package)
+            set_qpy_environment(self._env)
+
             self._question_type = cast("QuestionTypeInterface", package.interface)
 
         return LoadQPyPackage.Response(nssn=nssn)
@@ -198,7 +225,7 @@ class WorkerManager:
         if not self._question_type:
             self._raise_no_main_package_loaded(msg)
 
-        with self._with_request_user(msg.request_user):
+        with self._with_request_user(msg, msg.request_user):
             definition, form_data = self._question_type.get_options_form(msg.question_state)
 
             return GetOptionsForm.Response(definition=definition, form_data=form_data)
@@ -209,7 +236,7 @@ class WorkerManager:
         if not self._question_type:
             self._raise_no_main_package_loaded(msg)
 
-        with self._with_request_user(msg.request_user):
+        with self._with_request_user(msg, msg.request_user):
             question = self._question_type.create_question_from_options(msg.question_state, msg.form_data)
 
             return CreateQuestionFromOptions.Response(
@@ -222,7 +249,7 @@ class WorkerManager:
         if not self._question_type:
             self._raise_no_main_package_loaded(msg)
 
-        with self._with_request_user(msg.request_user):
+        with self._with_request_user(msg, msg.request_user):
             question = self._question_type.create_question_from_state(msg.question_state)
             attempt_started_model = question.start_attempt(msg.variant)
             return StartAttempt.Response(attempt_started_model=attempt_started_model)
@@ -233,7 +260,7 @@ class WorkerManager:
         if not self._question_type:
             self._raise_no_main_package_loaded(msg)
 
-        with self._with_request_user(msg.request_user):
+        with self._with_request_user(msg, msg.request_user):
             question = self._question_type.create_question_from_state(msg.question_state)
             attempt_model = question.get_attempt(msg.attempt_state, msg.scoring_state, msg.response)
             return ViewAttempt.Response(attempt_model=attempt_model)
@@ -244,7 +271,7 @@ class WorkerManager:
         if not self._question_type:
             self._raise_no_main_package_loaded(msg)
 
-        with self._with_request_user(msg.request_user):
+        with self._with_request_user(msg, msg.request_user):
             question = self._question_type.create_question_from_state(msg.question_state)
             attempt_scored_model = question.score_attempt(msg.attempt_state, msg.scoring_state, msg.response)
             return ScoreAttempt.Response(attempt_scored_model=attempt_scored_model)
@@ -260,20 +287,24 @@ class WorkerManager:
         raise MainPackageNotLoadedError(errmsg)
 
     @contextmanager
-    def _with_request_user(self, request_user: RequestUser) -> Generator[None, None, None]:
-        env = get_qpy_environment()
-        if env.request_user:
-            msg = "There is already a request_user in the current environment."
-            raise RuntimeError(msg)
+    def _with_request_user(self, msg: MessageToWorker, request_user: RequestUser) -> Generator[None, None, None]:
+        if not self._env:
+            self._raise_not_initialized(msg)
 
-        env.request_user = request_user
+        if self._env.request_user:
+            err_msg = "There is already a request_user in the current environment."
+            raise RuntimeError(err_msg)
+
+        self._env = dataclasses.replace(self._env, _request_user=request_user)
+        set_qpy_environment(self._env)
         try:
             for callback in self._on_request_callbacks:
                 callback(request_user)
 
             yield
         finally:
-            env.request_user = None
+            self._env = dataclasses.replace(self._env, _request_user=None)
+            set_qpy_environment(self._env)
 
 
 class PackageInitFailedError(Exception):

--- a/questionpy_server/worker/runtime/messages.py
+++ b/questionpy_server/worker/runtime/messages.py
@@ -2,6 +2,7 @@
 #  The QuestionPy Server is free software released under terms of the MIT license. See LICENSE.md.
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
 import traceback
+from collections.abc import Sequence
 from enum import IntEnum, StrEnum, auto, unique
 from pathlib import Path
 from struct import Struct
@@ -120,7 +121,11 @@ class LoadQPyPackage(MessageToWorker):
         """Success message in return to LoadQPyPackage."""
 
         message_id: ClassVar[MessageIds] = MessageIds.LOADED_QPY_PACKAGE
-        nssn: PackageNamespaceAndShortName
+
+        root_nssn: PackageNamespaceAndShortName
+        """NSSN of the package which was requested, to distinguish it from its loaded dependencies."""
+        loaded_packages: Sequence[PackageNamespaceAndShortName]
+        """All packages loaded as a result of THIS request, including dependencies."""
 
 
 class GetQPyPackageManifest(MessageToWorker):

--- a/questionpy_server/worker/runtime/package.py
+++ b/questionpy_server/worker/runtime/package.py
@@ -102,7 +102,7 @@ class RegularPackage(ImportablePackage):
 
     def resolve_static_dependencies(self) -> list[PackageLocation]:
         return [
-            DirPackageLocation(self.path / "dependencies" / "qpy" / dep.name / DIST_DIR)
+            DirPackageLocation(self.path / "dependencies" / "qpy" / dep.dir_name / DIST_DIR)
             for dep in self.manifest.dependencies.qpy
             if isinstance(dep, DistStaticQPyDependency)
         ]

--- a/questionpy_server/worker/runtime/package.py
+++ b/questionpy_server/worker/runtime/package.py
@@ -5,7 +5,6 @@ import inspect
 import logging
 import sys
 from abc import ABC, abstractmethod
-from functools import cached_property
 from importlib import import_module, resources
 from importlib.resources.abc import Traversable
 from pathlib import Path
@@ -14,8 +13,15 @@ from zipfile import ZipFile
 
 from questionpy_common.api.package import QPyPackageInterface
 from questionpy_common.constants import DIST_DIR, MANIFEST_FILENAME
-from questionpy_common.environment import Environment, Package, PackageState
-from questionpy_common.manifest import Manifest
+from questionpy_common.environment import (
+    Environment,
+    Package,
+    PackageNamespaceAndShortName,
+    PackageNotInitializedError,
+    PackageNotLoadedError,
+    PackageState,
+)
+from questionpy_common.manifest import DistStaticQPyDependency, Manifest
 from questionpy_server.worker.runtime.package_location import (
     DirPackageLocation,
     FunctionPackageLocation,
@@ -34,96 +40,74 @@ class NoInitFunctionError(Exception):
 class ImportablePackage(ABC, Package):
     """Adds methods needed for loading and running the package to :class:`Package`."""
 
-    def __init__(self) -> None:
-        self._state = PackageState.PREPARED
+    def __init__(self, manifest: Manifest) -> None:
+        self._manifest = manifest
 
-    @abstractmethod
-    def setup_imports(self) -> None:
-        """Modifies ``sys.path`` to include the package's python code."""
-
-    def init(self, env: Environment) -> QPyPackageInterface:
-        """Imports the package's entrypoint and executes its ``init`` function.
-
-        :meth:`setup_imports` should be called beforehand to allow the import.
-        """
-        main_module: ModuleType
-        if self.manifest.entrypoint:
-            main_module = import_module(
-                f"{self.manifest.namespace}.{self.manifest.short_name}.{self.manifest.entrypoint}"
-            )
-        else:
-            main_module = import_module(f"{self.manifest.namespace}.{self.manifest.short_name}")
-
-        self._state = PackageState.LOADED
-
-        if not hasattr(main_module, "init") or not callable(main_module.init):
-            raise NoInitFunctionError(main_module, "init")
-
-        signature = inspect.signature(main_module.init)
-        package_interface = main_module.init(*(self, env)[: len(signature.parameters)])
-        self._state = PackageState.INITIALIZED
-        return package_interface
-
-    @property
-    def state(self) -> PackageState:
-        return self._state
-
-
-class UnpackingZipBasedPackage(ImportablePackage):
-    """A zip-formatted QuestionPy package which will be unpacked into a temporary directory before use."""
-
-    def __init__(self, location: ZipPackageLocation, worker_home: Path) -> None:
-        super().__init__()
-        self.path = location.path
-        self.hash = location.hash
-
-        self._dir_package = self._unpack(worker_home / "packages" / self.hash)
-
-    def _unpack(self, to_dir: Path) -> "DirBasedPackage":
-        to_dir.mkdir(parents=True)
-        with ZipFile(self.path) as zip_file:
-            dist_prefix = f"{DIST_DIR}/"
-            for info in zip_file.infolist():
-                if info.filename.startswith(dist_prefix):
-                    zip_file.extract(info, to_dir)
-
-        _log.debug("Unpacked package '%s' to '%s'.", self.path, to_dir)
-
-        return DirBasedPackage(to_dir / DIST_DIR)
-
-    def setup_imports(self) -> None:
-        self._dir_package.setup_imports()
+        self._main_module: ModuleType | None = None
+        self._interface: QPyPackageInterface | None = None
+        self._dependencies: dict[PackageNamespaceAndShortName, ImportablePackage] = {}
 
     @property
     def manifest(self) -> Manifest:
-        return self._dir_package.manifest
+        return self._manifest
+
+    @property
+    def state(self) -> PackageState:
+        if self._interface is not None:
+            return PackageState.INITIALIZED
+        if self._main_module is not None:
+            return PackageState.LOADED
+        return PackageState.OPENED
+
+    @property
+    def dependencies(self) -> dict[PackageNamespaceAndShortName, "ImportablePackage"]:
+        return self._dependencies
+
+    @property
+    def interface(self) -> QPyPackageInterface:
+        if not self._interface:
+            raise PackageNotInitializedError
+        return self._interface
+
+    @abstractmethod
+    def load(self) -> None:
+        """Import the package's main module."""
+
+    @abstractmethod
+    def init(self, env: Environment) -> None:
+        """Executes the package's `init` function.
+
+        `load` must have been called beforehand.
+        """
+
+    @abstractmethod
+    def resolve_static_dependencies(self) -> list[PackageLocation]:
+        pass
+
+
+class RegularPackage(ImportablePackage):
+    """Implementation using a package dist directory, which might be run directly or extracted from a zip package."""
+
+    def __init__(self, path: Path, manifest: Manifest) -> None:
+        super().__init__(manifest)
+        self.path = path
 
     def get_path(self, path: str) -> Traversable:
-        return self._dir_package.get_path(path)
+        return self.path.joinpath(path)
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}({self.path})"
 
     __str__ = __repr__
 
+    def resolve_static_dependencies(self) -> list[PackageLocation]:
+        return [
+            DirPackageLocation(self.path / "dependencies" / "qpy" / dep.name / DIST_DIR)
+            for dep in self.manifest.dependencies.qpy
+            if isinstance(dep, DistStaticQPyDependency)
+        ]
 
-class DirBasedPackage(ImportablePackage):
-    """A package's dist directory to be used directly."""
-
-    def __init__(self, path: Path) -> None:
-        super().__init__()
-        self.path = path
-
-    @cached_property
-    def manifest(self) -> Manifest:
-        """Load QuestionPy manifest from package."""
-        manifest_path = self.path / MANIFEST_FILENAME
-        return Manifest.model_validate_json(manifest_path.read_bytes())
-
-    def get_path(self, path: str) -> Traversable:
-        return self.path.joinpath(path)
-
-    def setup_imports(self) -> None:
+    def load(self) -> None:
         for new_path in (
             str(self.path / "dependencies" / "site-packages"),
             str(self.path / "python"),
@@ -131,10 +115,22 @@ class DirBasedPackage(ImportablePackage):
             if new_path not in sys.path:
                 sys.path.insert(0, new_path)
 
-    def __repr__(self) -> str:
-        return f"{type(self).__name__}({self.path})"
+        if self.manifest.entrypoint:
+            self._main_module = import_module(
+                f"{self.manifest.namespace}.{self.manifest.short_name}.{self.manifest.entrypoint}"
+            )
+        else:
+            self._main_module = import_module(f"{self.manifest.namespace}.{self.manifest.short_name}")
 
-    __str__ = __repr__
+    def init(self, env: Environment) -> None:
+        if not self._main_module:
+            raise PackageNotLoadedError
+
+        if not hasattr(self._main_module, "init"):
+            raise NoInitFunctionError(self._main_module, "init")
+
+        signature = inspect.signature(self._main_module.init)
+        self._interface = self._main_module.init(*(self, env)[: len(signature.parameters)])
 
 
 class FunctionBasedPackage(ImportablePackage):
@@ -144,50 +140,72 @@ class FunctionBasedPackage(ImportablePackage):
     """
 
     def __init__(self, module_name: str, function_name: str, manifest: Manifest) -> None:
-        super().__init__()
+        super().__init__(manifest)
         self.module_name = module_name
         self.function_name = function_name
-        self._manifest = manifest
-
-    @property
-    def manifest(self) -> Manifest:
-        return self._manifest
 
     def get_path(self, path: str) -> Traversable:
         return resources.files(self.module_name).joinpath(path)
 
-    def setup_imports(self) -> None:
-        # Nothing to do.
-        pass
+    def load(self) -> None:
+        self._main_module = import_module(self.module_name)
 
-    def init(self, env: Environment) -> QPyPackageInterface:
-        main_module = import_module(self.module_name)
+    def init(self, env: Environment) -> None:
+        if not self._main_module:
+            raise PackageNotLoadedError
 
-        self._state = PackageState.LOADED
-
-        init_function = getattr(main_module, self.function_name, None)
-        if not init_function or not callable(init_function):
-            raise NoInitFunctionError(main_module, self.function_name)
+        init_function = getattr(self._main_module, self.function_name, None)
+        if not init_function:
+            raise NoInitFunctionError(self._main_module, self.function_name)
 
         signature = inspect.signature(init_function)
-        package_interface = init_function(*(self, env)[: len(signature.parameters)])
-        self._state = PackageState.INITIALIZED
-        return package_interface
+        self._interface = init_function(*(self, env)[: len(signature.parameters)])
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}({self.module_name, self.function_name})"
 
     __str__ = __repr__
 
+    def resolve_static_dependencies(self) -> list[PackageLocation]:
+        return []
 
-def load_package(location: PackageLocation, worker_home: Path) -> ImportablePackage:
+
+def _package_dir(worker_home: Path, manifest: Manifest) -> Path:
+    slug = f"{manifest.namespace}-{manifest.short_name}-{manifest.version}"
+    package_dir = worker_home / "packages" / slug
+    if package_dir.exists():
+        msg = f"A package with slug '{slug}' has already been loaded or is in the process of being loaded."
+        raise RuntimeError(msg)
+    return package_dir
+
+
+def open_qpy_package(location: PackageLocation, worker_home: Path) -> ImportablePackage:
     """Turn a pure :class:`PackageLocation` into an :class:`ImportablePackage` which can be imported and executed."""
-    if isinstance(location, ZipPackageLocation):
-        return UnpackingZipBasedPackage(location, worker_home)
-    if isinstance(location, DirPackageLocation):
-        return DirBasedPackage(location.path)
     if isinstance(location, FunctionPackageLocation):
         return FunctionBasedPackage(location.module_name, location.function_name, location.manifest)
+
+    if isinstance(location, ZipPackageLocation):
+        # Unpack the dist part of the ZIP into the package dir.
+        with ZipFile(location.path) as zip_file:
+            manifest = Manifest.model_validate_json(zip_file.read(f"{DIST_DIR}/{MANIFEST_FILENAME}"))
+            package_dir = _package_dir(worker_home, manifest)
+            package_dir.mkdir(parents=True)
+
+            dist_prefix = f"{DIST_DIR}/"
+            for info in zip_file.infolist():
+                if info.filename.startswith(dist_prefix):
+                    zip_file.extract(info, package_dir)
+
+        _log.debug("Unpacked package '%s' to '%s'.", location.path, package_dir)
+
+        return RegularPackage(package_dir / DIST_DIR, manifest)
+
+    if isinstance(location, DirPackageLocation):
+        manifest = Manifest.model_validate_json((location.path / MANIFEST_FILENAME).read_text())
+        package_dir = _package_dir(worker_home, manifest)
+        package_dir.parent.mkdir(parents=True, exist_ok=True)
+        package_dir.symlink_to(location.path)
+        return RegularPackage(package_dir, manifest)
 
     msg = f"Unknown package location: '{location}'"
     raise ValueError(msg)


### PR DESCRIPTION
Ich trenne den Lebenszyklus von Paketen jetzt in 2 Schritte. Erst wird ein Paket geöffnet aka prepared, im Falle von ZIP-Paketen geht damit das Entpacken einher. Dann wird das Manifest gelesen und anhand dessen werden alle Dependencies geöffnet (rekursiv). Wenn der gesamte Baum geöffnet wurde, werden alle Pakete linearisiert und initialisiert.

Die Trennung zwischen dem Öffnen und dem Initialisieren der Pakete halte ich an sich für sauber, aber erlaubt auch in Zukunft, dazwischen noch weitere Nachrichten hin-und her zu passen. Beispielsweise könnten dynamische Dependencies mit einer "Ich brauche noch folgende Pakete"-Nachricht vom Worker zum Server geschehen.

Außerdem fallen etwaige Dependency-Konflikte dann auf, bevor irgendein Paket initialisiert wird.

Closes: #158 