### PR TITLE
feat: make `context` a string

### DIFF
--- a/docs/qppe-server.yaml
+++ b/docs/qppe-server.yaml
@@ -649,10 +649,8 @@ components:
             - $ref: 'qppe-lms.yaml#/components/schemas/QuestionRef'
             - nullable: true
         context:
-          type: integer
+          type: string
           description: Some context information where the question is located (e.g. course or quiz/test id).
-          nullable: true
-          default: null
         callback_url:
           type: string
           format: uri
@@ -664,7 +662,7 @@ components:
         local_package:
           type: boolean
           description: True if the LMS is able to return the .qpy file through the LMS Callback API.
-      required: [ question_ref, callback_url, lms_auth_token, local_package ]
+      required: [ question_ref, context, callback_url, lms_auth_token, local_package ]
 
     QuestionCreateArguments:
       description: Information that is needed to create a new question.

--- a/questionpy_server/collector/indexer.py
+++ b/questionpy_server/collector/indexer.py
@@ -133,7 +133,7 @@ class Indexer:
                     # TODO: get Manifest without worker.
                     permissions = WorkerPermissions(1, 200 * MiB, 10, 4, {"trusted", "container"})
                     async with self._worker_pool.get_worker(
-                        ZipPackageLocation(path_or_manifest, package_hash), 0, None, permissions
+                        ZipPackageLocation(path_or_manifest, package_hash), 0, "manifest", permissions
                     ) as worker:
                         manifest = await worker.get_manifest()
                     package = Package(package_hash, manifest, source, path_or_manifest)

--- a/questionpy_server/models.py
+++ b/questionpy_server/models.py
@@ -62,7 +62,7 @@ class MainBaseModel(BaseModel):
 
 
 class RequestBaseData(MainBaseModel):
-    context: int | None = None
+    context: str
 
 
 class PackageDependenciesModel(BaseModel):

--- a/questionpy_server/web/_routes/_files.py
+++ b/questionpy_server/web/_routes/_files.py
@@ -28,10 +28,10 @@ async def serve_static_file(request: web.Request, package: Package) -> web.Respo
         # TODO: Support static files in non-main packages by using namespace and short_name.
         raise HTTPNotImplemented(text="Static file retrieval from non-main packages is not supported yet.")
 
-    permissions = qpy_server.worker_permissions.get_effective_permissions(package, None)
+    permissions = qpy_server.worker_permissions.get_effective_permissions(package, "files")
     location = await package.get_zip_package_location()
     worker: Worker
-    async with qpy_server.worker_pool.get_worker(location, 0, None, permissions) as worker:
+    async with qpy_server.worker_pool.get_worker(location, 0, "files", permissions) as worker:
         try:
             file = await worker.get_static_file(path)
         except FileNotFoundError as e:

--- a/questionpy_server/worker/permissions.py
+++ b/questionpy_server/worker/permissions.py
@@ -37,7 +37,7 @@ def _is_wildcard_matching(selector_value: str, package_value: str) -> bool:
     return selector_value in {package_value, "*"}
 
 
-def _is_selector_matching(selector: PackageSelector, package: Package, context: int | None) -> bool:
+def _is_selector_matching(selector: PackageSelector, package: Package, context: str) -> bool:
     return (
         # Package data.
         _is_wildcard_matching(selector.hash, package.hash)
@@ -49,13 +49,13 @@ def _is_selector_matching(selector: PackageSelector, package: Package, context: 
         and (selector.origin.local is None or selector.origin.local == package.sources.is_local())
         and _is_wildcard_matching(selector.origin.users, "*")  # TODO: handle users
         # Request data.
-        and _is_wildcard_matching(selector.request_context, str(context) if context else "")
+        and _is_wildcard_matching(selector.request_context, context)
     )
 
 
 class _WorkerPermissionIdentifier(NamedTuple):
     package: Package
-    context: int | None
+    context: str
 
 
 class WorkerPermissionsHandler:
@@ -100,14 +100,14 @@ class WorkerPermissionsHandler:
         specific_auto_grant_permissions = permissions.auto_grant_permissions.model_dump(exclude_none=True)
         return self._auto_grant_permissions.model_copy(update=specific_auto_grant_permissions)
 
-    def _get_specific_permissions(self, package: Package, context: int | None) -> SpecificWorkerPermissions | None:
+    def _get_specific_permissions(self, package: Package, context: str) -> SpecificWorkerPermissions | None:
         # We want to select the last defined one if multiple selectors match.
         for permissions in reversed(self._specific_package_permissions):
             if _is_selector_matching(permissions.package_selector, package, context):
                 return permissions
         return None
 
-    def get_effective_permissions(self, package: Package, context: int | None) -> EnvironmentWorkerPermissions:
+    def get_effective_permissions(self, package: Package, context: str) -> EnvironmentWorkerPermissions:
         """Gets the effective permissions for a package.
 
         TODO: also account for the current user

--- a/questionpy_server/worker/pool.py
+++ b/questionpy_server/worker/pool.py
@@ -44,7 +44,7 @@ def _memory_limit_or_zero(permissions: WorkerPermissions | None) -> int:
 class _IdleWorkersIdentifier(NamedTuple):
     package: PackageLocation
     lms: int
-    context: int | None
+    context: str
 
 
 class WorkerPool:
@@ -105,7 +105,7 @@ class WorkerPool:
 
     @asynccontextmanager
     async def get_worker(
-        self, package: PackageLocation, lms: int, context: int | None, permissions: WorkerPermissions
+        self, package: PackageLocation, lms: int, context: str, permissions: WorkerPermissions
     ) -> AsyncIterator[Worker]:
         """Get a (new) worker executing a QuestionPy package.
 
@@ -114,7 +114,7 @@ class WorkerPool:
         Args:
             package: path to QuestionPy package
             lms: id of the LMS
-            context: context id within the lms
+            context: context within the lms
             permissions: worker permissions
 
         Returns:
@@ -206,7 +206,7 @@ class WorkerPool:
         return f"{package_part}-{index}"
 
     async def _create_or_reuse_worker(
-        self, package: PackageLocation, lms: int, context: int | None, permissions: WorkerPermissions
+        self, package: PackageLocation, lms: int, context: str, permissions: WorkerPermissions
     ) -> Worker:
         """If possible, get an idle worker or create a new one."""
         # Since the `WorkerPermissions` only dependent on the the `lms` and `context` the worker
@@ -238,9 +238,7 @@ class WorkerPool:
 
         return worker
 
-    async def _handle_idle_worker(
-        self, package: PackageLocation, lms: int, context: int | None, worker: Worker
-    ) -> None:
+    async def _handle_idle_worker(self, package: PackageLocation, lms: int, context: str, worker: Worker) -> None:
         """Adds a worker to the pool of reusable workers."""
         # Free reserved memory.
         self._memory_in_use -= _memory_limit_or_zero(worker.permissions)

--- a/ruff_defaults.toml
+++ b/ruff_defaults.toml
@@ -102,7 +102,6 @@ ignore = [
   # bandit
   "S404", # allow `subprocess`
   "S311", # don't flag `random.*`
-  "S320", # allow XML parsing using lxml
 
   # ruff doesn't track inheritance across files, disabling to prevent false positives
   # https://github.com/astral-sh/ruff/issues/5243#issuecomment-1860862939

--- a/tests/questionpy_common/test_elements.py
+++ b/tests/questionpy_common/test_elements.py
@@ -48,7 +48,7 @@ _METHOD = "POST"
 _URL = f"packages/{_PACKAGE_HASH}/options"
 
 _QUESTION_STATE = (test_data_path / "question_state" / "question_state.json").read_text()
-_REQUEST_MAIN = json.dumps({"context": 1})
+_REQUEST_MAIN = json.dumps({"context": "tests"})
 
 
 async def test_should_validate_main_body_when_question_state_is_not_given(client: TestClient) -> None:

--- a/tests/questionpy_server/web/middlewares/test_error_middleware.py
+++ b/tests/questionpy_server/web/middlewares/test_error_middleware.py
@@ -174,7 +174,7 @@ async def test_invalid_options_form_data_error(client: TestClient) -> None:
         part = writer.append(package_fd)
         part.set_content_disposition("form-data", name="package")
 
-        part = writer.append_json({"form_data": {}})
+        part = writer.append_json({"form_data": {}, "context": "tests"})
         part.set_content_disposition("form-data", name="main")
 
         res = await client.post(

--- a/tests/questionpy_server/web/routes/test_files.py
+++ b/tests/questionpy_server/web/routes/test_files.py
@@ -1,10 +1,14 @@
 #  This file is part of the QuestionPy Server. (https://questionpy.org)
 #  The QuestionPy Server is free software released under terms of the MIT license. See LICENSE.md.
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+import json
+
 import pytest
 from aiohttp.test_utils import TestClient
 
 from tests.conftest import PACKAGE, TestPackageFactory, TestZipPackage
+
+_REQUEST_MAIN = json.dumps({"context": "tests"})
 
 
 @pytest.fixture
@@ -17,7 +21,8 @@ def package(package_factory: TestPackageFactory) -> TestZipPackage:
 async def test_should_get_static_file(client: TestClient, package: TestZipPackage) -> None:
     with package.path.open("rb") as package_fd:
         res = await client.post(
-            f"/packages/{package.hash}/file/local/package_1/static/path/to/file.pdf", data={"package": package_fd}
+            f"/packages/{package.hash}/file/local/package_1/static/path/to/file.pdf",
+            data={"package": package_fd, "main": _REQUEST_MAIN},
         )
 
     assert res.status == 200
@@ -29,7 +34,7 @@ async def test_should_return_not_implemented_when_not_main_package(client: TestC
     with package.path.open("rb") as package_fd:
         res = await client.post(
             f"/packages/{package.hash}/file/some_other_ns/and_short_name/static/path/to/file.pdf",
-            data={"package": package_fd},
+            data={"package": package_fd, "main": _REQUEST_MAIN},
         )
 
     assert res.status == 501
@@ -39,7 +44,8 @@ async def test_should_return_not_implemented_when_not_main_package(client: TestC
 async def test_should_return_not_found_when_file_does_not_exist(client: TestClient, package: TestZipPackage) -> None:
     with package.path.open("rb") as package_fd:
         res = await client.post(
-            f"/packages/{package.hash}/file/local/package_1/static/wrong/path/to/file.pdf", data={"package": package_fd}
+            f"/packages/{package.hash}/file/local/package_1/static/wrong/path/to/file.pdf",
+            data={"package": package_fd, "main": _REQUEST_MAIN},
         )
 
     assert res.status == 404

--- a/tests/questionpy_server/worker/impl/test_base.py
+++ b/tests/questionpy_server/worker/impl/test_base.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 
 async def test_should_get_manifest(worker_pool: WorkerPool) -> None:
-    async with worker_pool.get_worker(PACKAGE, 1, 1, DEFAULT_WORKER_PERMISSIONS) as worker:
+    async with worker_pool.get_worker(PACKAGE, 1, "tests", DEFAULT_WORKER_PERMISSIONS) as worker:
         manifest = await worker.get_manifest()
         assert manifest == PACKAGE.manifest
 
@@ -41,7 +41,7 @@ async def test_should_get_static_file(
 
     package: PackageLocation = dir_package if package_type == "dir" else package_factory.to_zip_package(dir_package)
 
-    async with worker_pool.get_worker(package, 1, 1, DEFAULT_WORKER_PERMISSIONS) as worker:
+    async with worker_pool.get_worker(package, 1, "tests", DEFAULT_WORKER_PERMISSIONS) as worker:
         static_file = await worker.get_static_file(_STATIC_FILE_NAME)
 
     assert static_file.data == _STATIC_FILE_CONTENT.encode()
@@ -58,7 +58,7 @@ async def test_should_raise_file_not_found_error_when_not_in_manifest(
 
     package: PackageLocation = dir_package if package_type == "dir" else package_factory.to_zip_package(dir_package)
 
-    async with worker_pool.get_worker(package, 1, 1, DEFAULT_WORKER_PERMISSIONS) as worker:
+    async with worker_pool.get_worker(package, 1, "tests", DEFAULT_WORKER_PERMISSIONS) as worker:
         with pytest.raises(FileNotFoundError):
             await worker.get_static_file(_STATIC_FILE_NAME)
 
@@ -83,7 +83,7 @@ async def test_should_raise_file_not_found_error_when_file_is_outside(
         else package_factory.to_zip_package(dir_package, include_siblings=("my_secret_file",))
     )
 
-    async with worker_pool.get_worker(package, 1, 1, DEFAULT_WORKER_PERMISSIONS) as worker:
+    async with worker_pool.get_worker(package, 1, "tests", DEFAULT_WORKER_PERMISSIONS) as worker:
         with caplog.at_level(logging.INFO), pytest.raises(FileNotFoundError):
             await worker.get_static_file("static/../../my_secret_file")
 
@@ -103,7 +103,7 @@ async def test_should_raise_file_not_found_error_when_symlink_target_is_outside(
 
     package.inject_static_file_into_manifest("static/my_secret_file", len(content), "text/plain")
 
-    async with worker_pool.get_worker(package, 1, 1, DEFAULT_WORKER_PERMISSIONS) as worker:
+    async with worker_pool.get_worker(package, 1, "tests", DEFAULT_WORKER_PERMISSIONS) as worker:
         with caplog.at_level(logging.INFO), pytest.raises(FileNotFoundError):
             await worker.get_static_file("static/my_secret_file")
 
@@ -119,7 +119,7 @@ async def test_should_raise_file_not_found_error_when_not_on_disk(
 
     package: PackageLocation = dir_package if package_type == "dir" else package_factory.to_zip_package(dir_package)
 
-    async with worker_pool.get_worker(package, 1, 1, DEFAULT_WORKER_PERMISSIONS) as worker:
+    async with worker_pool.get_worker(package, 1, "tests", DEFAULT_WORKER_PERMISSIONS) as worker:
         with pytest.raises(FileNotFoundError):
             await worker.get_static_file(_STATIC_FILE_NAME)
 
@@ -134,7 +134,7 @@ async def test_should_raise_static_file_size_mismatch_error_when_sizes_dont_matc
 
     package: PackageLocation = dir_package if package_type == "dir" else package_factory.to_zip_package(dir_package)
 
-    async with worker_pool.get_worker(package, 1, 1, DEFAULT_WORKER_PERMISSIONS) as worker:
+    async with worker_pool.get_worker(package, 1, "tests", DEFAULT_WORKER_PERMISSIONS) as worker:
         with pytest.raises(StaticFileSizeMismatchError):
             await worker.get_static_file(_STATIC_FILE_NAME)
 
@@ -163,13 +163,13 @@ def _make_get_manifest_raise() -> Iterator[None]:
 @pytest.mark.filterwarnings("ignore:Exception in thread worker-")
 async def test_should_gracefully_handle_error_in_bootstrap(worker_pool: WorkerPool) -> None:
     with patch_worker_pool(worker_pool, _make_bootstrap_raise), pytest.raises(WorkerStartError):
-        async with worker_pool.get_worker(PACKAGE, 1, 1, DEFAULT_WORKER_PERMISSIONS):
+        async with worker_pool.get_worker(PACKAGE, 1, "tests", DEFAULT_WORKER_PERMISSIONS):
             pass
 
 
 async def test_should_gracefully_handle_error_in_loop(worker_pool: WorkerPool) -> None:
     with patch_worker_pool(worker_pool, _make_get_manifest_raise):
-        async with worker_pool.get_worker(PACKAGE, 1, 1, DEFAULT_WORKER_PERMISSIONS) as worker:
+        async with worker_pool.get_worker(PACKAGE, 1, "tests", DEFAULT_WORKER_PERMISSIONS) as worker:
             with pytest.raises(WorkerUnknownError, match="some custom error"):
                 await worker.get_manifest()
 

--- a/tests/questionpy_server/worker/impl/test_subprocess.py
+++ b/tests/questionpy_server/worker/impl/test_subprocess.py
@@ -25,7 +25,7 @@ from tests.questionpy_server.worker.impl.conftest import patch_worker_pool
 
 @pytest.mark.parametrize("worker_pool", [SubprocessWorker], indirect=True)
 async def test_should_apply_limits(worker_pool: WorkerPool) -> None:
-    async with worker_pool.get_worker(PACKAGE, 1, 1, DEFAULT_WORKER_PERMISSIONS) as worker:
+    async with worker_pool.get_worker(PACKAGE, 1, "tests", DEFAULT_WORKER_PERMISSIONS) as worker:
         assert isinstance(worker, SubprocessWorker)
         assert worker._proc
         # Python's resource package can only get the rlimit of other processes on Linux, so we use psutil.
@@ -52,7 +52,7 @@ async def test_should_raise_cpu_timout_error(worker_pool: WorkerPool) -> None:
         start_time = time()
         # Change the timeout for faster testing.
         with pytest.raises(WorkerStartError) as exc_info, patch.object(BaseWorker, "_init_worker_timeout", 0.05):
-            async with worker_pool.get_worker(PACKAGE, 1, 1, DEFAULT_WORKER_PERMISSIONS):
+            async with worker_pool.get_worker(PACKAGE, 1, "tests", DEFAULT_WORKER_PERMISSIONS):
                 pass
         assert isinstance(exc_info.value.__cause__, WorkerCPUTimeLimitExceededError)
         assert 0.05 < (time() - start_time) < 0.5
@@ -79,7 +79,7 @@ async def test_should_raise_real_timout_error(worker_pool: WorkerPool) -> None:
             patch.object(BaseWorker, "_init_worker_timeout", 0.6),
             patch.object(LimitTimeUsageMixin, "_real_time_limit_factor", 1.0),
         ):
-            async with worker_pool.get_worker(PACKAGE, 1, 1, DEFAULT_WORKER_PERMISSIONS) as worker:
+            async with worker_pool.get_worker(PACKAGE, 1, "tests", DEFAULT_WORKER_PERMISSIONS) as worker:
                 await worker.get_manifest()
         assert isinstance(exc_info.value.__cause__, WorkerRealTimeLimitExceededError)
         assert 0.6 < (time() - start_time) < 2.0

--- a/tests/questionpy_server/worker/impl/test_thread.py
+++ b/tests/questionpy_server/worker/impl/test_thread.py
@@ -15,7 +15,7 @@ from tests.conftest import DEFAULT_WORKER_PERMISSIONS, PACKAGE
 @pytest.mark.parametrize("worker_pool", [ThreadWorker], indirect=True)
 async def test_should_ignore_limits(worker_pool: WorkerPool) -> None:
     with patch.object(resource, "setrlimit") as mock:
-        async with worker_pool.get_worker(PACKAGE, 1, 1, DEFAULT_WORKER_PERMISSIONS):
+        async with worker_pool.get_worker(PACKAGE, 1, "tests", DEFAULT_WORKER_PERMISSIONS):
             pass
 
         mock.assert_not_called()


### PR DESCRIPTION
> Eine Überlegung ist es den Typ vom context von `int | None` zu `str | None` zu ändern. Dadurch sollen auch LMSe unterstützt werden, die keinen `context` als `int` angeben können (im `context` könnte dann z.B. "kurs xyz" stehen).

(aus #169)

@MartinGauk meinte, dass wir vermutlich gar keinen `None`-Kontext unterstützen müssen - mir ist auch kein Beispiel eingefallen. Aus diesem Grund ist jetzt `context` nicht mehr nullable.