### PR TITLE
Umbenennung zu Adjusted Score

### DIFF
--- a/docs/qppe-server.yaml
+++ b/docs/qppe-server.yaml
@@ -713,9 +713,9 @@ components:
               enum:
                 - ALWAYS_MANUAL_SCORING_REQUIRED
                 - AUTOMATICALLY_SCORABLE
-                - AUTOMATICALLY_SCORABLE_WITH_COUNTBACK
-              description: AUTOMATICALLY_SCORABLE_WITH_COUNTBACK means the package is able to compute a final score,
-                taking into account previous submissions to this question.
+                - AUTOMATICALLY_SCORABLE_WITH_SCORE_ADJUSTMENT
+              description: AUTOMATICALLY_SCORABLE_WITH_SCORE_ADJUSTMENT means the package is able to compute
+                an adjusted score, taking into account previous submissions to this question.
             penalty:
               type: number
               format: double
@@ -958,14 +958,14 @@ components:
                 reached, the server will score the attempt in background and push the score to the LMS (asynchronous
                 scoring). Null if there should be no timeout (only synchronous scoring) or
                 zero for asynchronous scoring only.
-            try_scoring_with_countback:
+            compute_adjusted_score:
               type: boolean
-              description: Try to compute a final score, taking into account previous submissions to this question
-                (only when question.scoring_method is AUTOMATICALLY_SCORABLE_WITH_COUNTBACK).
+              description: Try to compute an adjusted score, taking into account previous submissions to this question
+                (only when Question.scoring_method is AUTOMATICALLY_SCORABLE_WITH_SCORE_ADJUSTMENT).
             generate_hint:
               type: boolean
               description: Try to give a hint on how to improve the response.
-          required: [ response, timeout, try_scoring_with_countback, generate_hint ]
+          required: [ response, timeout, compute_adjusted_score, generate_hint ]
 
     AttemptScored:
       allOf:
@@ -989,10 +989,13 @@ components:
               nullable: true
               description: The score for this question attempt, must lie between the `score_min` and `score_max` set by
                 the question.
-            score_final:
+            score_adjusted:
               type: number
               format: double
               nullable: true
+              description: An adjusted score (between `score_min` and `score_max` set by the question) that is
+                computed based on previous submissions (computed only when
+                AttemptScoreArguments.compute_adjusted_score is true).
             scored_inputs:
               type: object
               default: { }
@@ -1023,7 +1026,7 @@ components:
                     format: double
                     nullable: true
                     default: null
-                  score_final:
+                  score_adjusted:
                     type: number
                     format: double
                     nullable: true

--- a/questionpy_common/api/attempt.py
+++ b/questionpy_common/api/attempt.py
@@ -121,7 +121,7 @@ class ScoredInputModel(BaseModel):
 
 class ScoredSubquestionModel(BaseModel):
     score: float | None = None
-    score_final: float | None = None
+    score_adjusted: float | None = None
     scoring_code: ScoringCode | None = None
     response_summary: str
     response_class: str
@@ -132,7 +132,7 @@ class ScoreModel(BaseModel):
     scoring_code: ScoringCode
     score: float | None
     """The score for this question attempt, must lie between the `score_min` and `score_max` set by the question."""
-    score_final: float | None
+    score_adjusted: float | None
     scored_inputs: dict[str, ScoredInputModel] = {}
     """Maps input names to their individual scores."""
     scored_subquestions: dict[str, ScoredSubquestionModel] = {}

--- a/questionpy_common/api/question.py
+++ b/questionpy_common/api/question.py
@@ -16,7 +16,7 @@ __all__ = ["PossibleResponse", "QuestionInterface", "QuestionModel", "ScoringMet
 class ScoringMethod(Enum):
     ALWAYS_MANUAL_SCORING_REQUIRED = "ALWAYS_MANUAL_SCORING_REQUIRED"
     AUTOMATICALLY_SCORABLE = "AUTOMATICALLY_SCORABLE"
-    AUTOMATICALLY_SCORABLE_WITH_COUNTBACK = "AUTOMATICALLY_SCORABLE_WITH_COUNTBACK"
+    AUTOMATICALLY_SCORABLE_WITH_SCORE_ADJUSTMENT = "AUTOMATICALLY_SCORABLE_WITH_SCORE_ADJUSTMENT"
 
 
 class PossibleResponse(BaseModel):
@@ -75,8 +75,8 @@ class QuestionInterface(Protocol):
         scoring_state: str | None = None,
         response: dict[str, JsonValue] | None = None,
         *,
-        try_scoring_with_countback: bool = False,
-        try_giving_hint: bool = False,
+        compute_adjusted_score: bool = False,
+        generate_hint: bool = False,
     ) -> AttemptScoredModel:
         """Create an attempt object for a previously started attempt.
 
@@ -85,8 +85,8 @@ class QuestionInterface(Protocol):
                            [start_attempt][].
             scoring_state: Not implemented.
             response: The response currently entered by the student.
-            try_scoring_with_countback: TBD
-            try_giving_hint: TBD
+            compute_adjusted_score: TBD
+            generate_hint: TBD
         """
 
     @abstractmethod


### PR DESCRIPTION
Ich habe mir mal ein paar Gedanken zu der Funktion Countback / Final Score gemacht und mit der KI gesprochen. Die Begriffe sind wahrscheinlich nicht so günstig und ich möchte sie daher austauschen. Aus `try_scoring_with_countback` mache ich `compute_adjusted_score`, aus `score_final` wird `score_adjusted`. Ich denke, dass durch "adjust" die Funktionalität besser beschrieben und einheitlicher benannt wird. Adjusted Score passt besser, weil die Studierenden ja auch eine Rückmeldung erhalten sollten über ihre aktuellen vorläufigen Punkte, auch wenn sie noch weitere Versuche probieren.

Bei der Gelegenheit habe ich außerdem aus `try_giving_hint` `generate_hint` gemacht. Letzteres war bereits in der QPPE als Begriff benutzt und gefällt mir besser.