### PR TITLE
feat: introduce `request_user` in the  `PackageSelector`

### DIFF
--- a/questionpy_server/settings.py
+++ b/questionpy_server/settings.py
@@ -119,6 +119,7 @@ class PackageOrigin(BaseModel):
 
 class PackageSelector(BaseModel):
     origin: PackageOrigin = PackageOrigin()
+    request_user: str = "*"
     request_context: str = "*"
     namespace: str = "*"
     short_name: str = "*"

--- a/questionpy_server/web/_routes/_attempts.py
+++ b/questionpy_server/web/_routes/_attempts.py
@@ -2,8 +2,6 @@
 #  The QuestionPy Server is free software released under terms of the MIT license. See LICENSE.md.
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
 
-from typing import TYPE_CHECKING
-
 from aiohttp import web
 
 from questionpy_server.models import (
@@ -16,11 +14,8 @@ from questionpy_server.models import (
 )
 from questionpy_server.package import Package
 from questionpy_server.web._decorators import ensure_required_parts
-from questionpy_server.web._utils import DEFAULT_REQUEST_USER, pydantic_json_response
+from questionpy_server.web._utils import CURRENT_USER_KEY, DEFAULT_REQUEST_USER, pydantic_json_response
 from questionpy_server.web.app import QPyServer
-
-if TYPE_CHECKING:
-    from questionpy_server.worker import Worker
 
 attempt_routes = web.RouteTableDef()
 
@@ -32,10 +27,11 @@ async def post_attempt_start(
 ) -> web.Response:
     qpyserver = request.app[QPyServer.APP_KEY]
 
-    permissions = qpyserver.worker_permissions.get_effective_permissions(package, data.context)
+    current_user = request.get(CURRENT_USER_KEY)
+    permissions = qpyserver.worker_permissions.get_effective_permissions(package, current_user, data.context)
     location = await package.get_zip_package_location()
-    worker: Worker
-    async with qpyserver.worker_pool.get_worker(location, 0, data.context, permissions) as worker:
+
+    async with qpyserver.worker_pool.get_worker(location, current_user, data.context, permissions) as worker:
         attempt = await worker.start_attempt(DEFAULT_REQUEST_USER, question_state.decode(), data.variant)
         packages = worker.get_loaded_packages()
 
@@ -50,10 +46,11 @@ async def post_attempt_view(
 ) -> web.Response:
     qpyserver = request.app[QPyServer.APP_KEY]
 
-    permissions = qpyserver.worker_permissions.get_effective_permissions(package, data.context)
+    current_user = request.get(CURRENT_USER_KEY)
+    permissions = qpyserver.worker_permissions.get_effective_permissions(package, current_user, data.context)
     location = await package.get_zip_package_location()
-    worker: Worker
-    async with qpyserver.worker_pool.get_worker(location, 0, data.context, permissions) as worker:
+
+    async with qpyserver.worker_pool.get_worker(location, current_user, data.context, permissions) as worker:
         attempt = await worker.get_attempt(
             request_user=DEFAULT_REQUEST_USER,
             question_state=question_state.decode(),
@@ -74,10 +71,11 @@ async def post_attempt_score(
 ) -> web.Response:
     qpyserver = request.app[QPyServer.APP_KEY]
 
-    permissions = qpyserver.worker_permissions.get_effective_permissions(package, data.context)
+    current_user = request.get(CURRENT_USER_KEY)
+    permissions = qpyserver.worker_permissions.get_effective_permissions(package, current_user, data.context)
     location = await package.get_zip_package_location()
-    worker: Worker
-    async with qpyserver.worker_pool.get_worker(location, 0, data.context, permissions) as worker:
+
+    async with qpyserver.worker_pool.get_worker(location, current_user, data.context, permissions) as worker:
         attempt_scored = await worker.score_attempt(
             request_user=DEFAULT_REQUEST_USER,
             question_state=question_state.decode(),

--- a/questionpy_server/web/_routes/_files.py
+++ b/questionpy_server/web/_routes/_files.py
@@ -1,17 +1,14 @@
 #  This file is part of the QuestionPy Server. (https://questionpy.org)
 #  The QuestionPy Server is free software released under terms of the MIT license. See LICENSE.md.
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
-from typing import TYPE_CHECKING
 
 from aiohttp import web
 from aiohttp.web_exceptions import HTTPNotImplemented
 
 from questionpy_server.package import Package
 from questionpy_server.web._decorators import ensure_package
+from questionpy_server.web._utils import CURRENT_USER_KEY
 from questionpy_server.web.app import QPyServer
-
-if TYPE_CHECKING:
-    from questionpy_server.worker import Worker
 
 file_routes = web.RouteTableDef()
 
@@ -28,10 +25,11 @@ async def serve_static_file(request: web.Request, package: Package) -> web.Respo
         # TODO: Support static files in non-main packages by using namespace and short_name.
         raise HTTPNotImplemented(text="Static file retrieval from non-main packages is not supported yet.")
 
-    permissions = qpy_server.worker_permissions.get_effective_permissions(package, "files")
+    current_user = request.get(CURRENT_USER_KEY)
+    permissions = qpy_server.worker_permissions.get_effective_permissions(package, current_user, "files")
     location = await package.get_zip_package_location()
-    worker: Worker
-    async with qpy_server.worker_pool.get_worker(location, 0, "files", permissions) as worker:
+
+    async with qpy_server.worker_pool.get_worker(location, current_user, "files", permissions) as worker:
         try:
             file = await worker.get_static_file(path)
         except FileNotFoundError as e:

--- a/questionpy_server/web/_routes/_packages.py
+++ b/questionpy_server/web/_routes/_packages.py
@@ -2,20 +2,15 @@
 #  The QuestionPy Server is free software released under terms of the MIT license. See LICENSE.md.
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
 
-from typing import TYPE_CHECKING
-
 from aiohttp import web
 from aiohttp.web_exceptions import HTTPMethodNotAllowed
 
 from questionpy_server.models import QuestionCreateArguments, QuestionEditFormResponse, RequestBaseData
 from questionpy_server.package import Package
 from questionpy_server.web._decorators import ensure_package, ensure_required_parts
-from questionpy_server.web._utils import DEFAULT_REQUEST_USER, pydantic_json_response
+from questionpy_server.web._utils import CURRENT_USER_KEY, DEFAULT_REQUEST_USER, pydantic_json_response
 from questionpy_server.web.app import QPyServer
 from questionpy_server.web.errors import PackageNotFoundError
-
-if TYPE_CHECKING:
-    from questionpy_server.worker import Worker
 
 package_routes = web.RouteTableDef()
 
@@ -48,10 +43,11 @@ async def post_options(
     """Get the options form definition that allow a question creator to customize a question."""
     qpyserver = request.app[QPyServer.APP_KEY]
 
-    permissions = qpyserver.worker_permissions.get_effective_permissions(package, data.context)
+    current_user = request.get(CURRENT_USER_KEY)
+    permissions = qpyserver.worker_permissions.get_effective_permissions(package, current_user, data.context)
     location = await package.get_zip_package_location()
-    worker: Worker
-    async with qpyserver.worker_pool.get_worker(location, 0, data.context, permissions) as worker:
+
+    async with qpyserver.worker_pool.get_worker(location, current_user, data.context, permissions) as worker:
         definition, form_data = await worker.get_options_form(
             DEFAULT_REQUEST_USER, question_state.decode() if question_state else None
         )
@@ -69,10 +65,11 @@ async def post_question(
 ) -> web.Response:
     qpyserver = request.app[QPyServer.APP_KEY]
 
-    permissions = qpyserver.worker_permissions.get_effective_permissions(package, data.context)
+    current_user = request.get(CURRENT_USER_KEY)
+    permissions = qpyserver.worker_permissions.get_effective_permissions(package, current_user, data.context)
     location = await package.get_zip_package_location()
-    worker: Worker
-    async with qpyserver.worker_pool.get_worker(location, 0, data.context, permissions) as worker:
+
+    async with qpyserver.worker_pool.get_worker(location, current_user, data.context, permissions) as worker:
         question = await worker.create_question_from_options(
             DEFAULT_REQUEST_USER, question_state.decode() if question_state else None, data.form_data
         )

--- a/questionpy_server/web/_utils.py
+++ b/questionpy_server/web/_utils.py
@@ -69,3 +69,4 @@ async def read_part(part: BodyPartReader, max_size: int, *, calculate_hash: bool
 
 # TODO: Replace with Accept-Language header contents.
 DEFAULT_REQUEST_USER = RequestUser([Bcp47LanguageTag("de"), Bcp47LanguageTag("en")])
+CURRENT_USER_KEY = "qpy-current-user"

--- a/questionpy_server/web/middlewares/_authentication.py
+++ b/questionpy_server/web/middlewares/_authentication.py
@@ -10,6 +10,7 @@ from aiohttp.web_request import Request
 from aiohttp.web_response import StreamResponse
 
 from questionpy_server.settings import AuthSettings
+from questionpy_server.web._utils import CURRENT_USER_KEY
 
 PASSWORD_ENCODING = "utf-8"  # noqa: S105
 
@@ -61,6 +62,7 @@ async def auth_middleware(request: Request, handler: Handler) -> StreamResponse:
 
     credentials = get_credentials(request)
     if check_credentials(credentials, settings.users):
+        request[CURRENT_USER_KEY] = credentials.login
         return await handler(request)
 
     raise HTTPUnauthorizedBasicAuth(reason="Invalid credentials")

--- a/questionpy_server/worker/permissions.py
+++ b/questionpy_server/worker/permissions.py
@@ -37,7 +37,7 @@ def _is_wildcard_matching(selector_value: str, package_value: str) -> bool:
     return selector_value in {package_value, "*"}
 
 
-def _is_selector_matching(selector: PackageSelector, package: Package, context: str) -> bool:
+def _is_selector_matching(selector: PackageSelector, package: Package, user: str | None, context: str) -> bool:
     return (
         # Package data.
         _is_wildcard_matching(selector.hash, package.hash)
@@ -49,12 +49,14 @@ def _is_selector_matching(selector: PackageSelector, package: Package, context: 
         and (selector.origin.local is None or selector.origin.local == package.sources.is_local())
         and _is_wildcard_matching(selector.origin.users, "*")  # TODO: handle users
         # Request data.
+        and _is_wildcard_matching(selector.request_user, str(user) if user else "")
         and _is_wildcard_matching(selector.request_context, context)
     )
 
 
 class _WorkerPermissionIdentifier(NamedTuple):
     package: Package
+    user: str | None
     context: str
 
 
@@ -100,29 +102,31 @@ class WorkerPermissionsHandler:
         specific_auto_grant_permissions = permissions.auto_grant_permissions.model_dump(exclude_none=True)
         return self._auto_grant_permissions.model_copy(update=specific_auto_grant_permissions)
 
-    def _get_specific_permissions(self, package: Package, context: str) -> SpecificWorkerPermissions | None:
+    def _get_specific_permissions(
+        self, package: Package, user: str | None, context: str
+    ) -> SpecificWorkerPermissions | None:
         # We want to select the last defined one if multiple selectors match.
         for permissions in reversed(self._specific_package_permissions):
-            if _is_selector_matching(permissions.package_selector, package, context):
+            if _is_selector_matching(permissions.package_selector, package, user, context):
                 return permissions
         return None
 
-    def get_effective_permissions(self, package: Package, context: str) -> EnvironmentWorkerPermissions:
+    def get_effective_permissions(
+        self, package: Package, user: str | None, context: str
+    ) -> EnvironmentWorkerPermissions:
         """Gets the effective permissions for a package.
-
-        TODO: also account for the current user
 
         Raises:
             WorkerPermissionError: If the package does not have enough permissions.
         """
-        key = _WorkerPermissionIdentifier(package, context)
+        key = _WorkerPermissionIdentifier(package, user, context)
         if cached_permissions := self._cache.get(key):
             return cached_permissions
 
         auto_grant_permissions = self._auto_grant_permissions
         requested_permissions = self._get_requested_permissions(package)
 
-        if specific_permissions := self._get_specific_permissions(package, context):
+        if specific_permissions := self._get_specific_permissions(package, user, context):
             auto_grant_permissions = self._get_actual_auto_grant_permissions(specific_permissions)
 
             if specific_permissions.override_permissions:

--- a/questionpy_server/worker/pool.py
+++ b/questionpy_server/worker/pool.py
@@ -38,7 +38,7 @@ class _WorkerPoolMemoryError(QPyBaseError):
 
 class _IdleWorkersIdentifier(NamedTuple):
     package: PackageLocation
-    lms: int
+    user: str | None
     context: str
 
 
@@ -100,7 +100,7 @@ class WorkerPool:
 
     @asynccontextmanager
     async def get_worker(
-        self, package: PackageLocation, lms: int, context: str, permissions: WorkerPermissions
+        self, package: PackageLocation, user: str | None, context: str, permissions: WorkerPermissions
     ) -> AsyncIterator[Worker]:
         """Get a (new) worker executing a QuestionPy package.
 
@@ -108,7 +108,7 @@ class WorkerPool:
 
         Args:
             package: path to QuestionPy package
-            lms: id of the LMS
+            user: the user requesting the worker
             context: context within the lms
             permissions: worker permissions
 
@@ -132,14 +132,14 @@ class WorkerPool:
                 # `Lock.acquire` is not explicitly documented as fair. This ensures that no starvation occurs.
                 async with self._lock, self._condition:
                     await self._condition.wait_for(lambda: self._memory_available(permissions.memory))
-                    worker = await self._create_or_reuse_worker(package, lms, context, permissions)
+                    worker = await self._create_or_reuse_worker(package, user, context, permissions)
                     self._workers_in_use += 1
 
                 yield worker
             finally:
                 if worker:
                     async with self._condition:
-                        await self._handle_idle_worker(package, lms, context, worker)
+                        await self._handle_idle_worker(package, user, context, worker)
                         self._condition.notify()
                         self._workers_in_use -= 1
 
@@ -200,13 +200,12 @@ class WorkerPool:
         return f"{package_part}-{index}"
 
     async def _create_or_reuse_worker(
-        self, package: PackageLocation, lms: int, context: str, permissions: WorkerPermissions
+        self, package: PackageLocation, user: str | None, context: str, permissions: WorkerPermissions
     ) -> Worker:
         """If possible, get an idle worker or create a new one."""
-        # Since the `WorkerPermissions` only dependent on the the `lms` and `context` the worker
+        # Since the `WorkerPermissions` only dependent on the `user` and `context` the worker
         # permissions are the same.
-        # TODO: this is currently not entirely true as the `lms` (later `user`) is not accounted for yet.
-        identifier = _IdleWorkersIdentifier(package, lms, context)
+        identifier = _IdleWorkersIdentifier(package, user, context)
         if identifier in self._idle_workers:
             # There is an idle worker with this package loaded - reuse the most recent one.
             worker = self._idle_workers[identifier].popleft()
@@ -232,7 +231,9 @@ class WorkerPool:
 
         return worker
 
-    async def _handle_idle_worker(self, package: PackageLocation, lms: int, context: str, worker: Worker) -> None:
+    async def _handle_idle_worker(
+        self, package: PackageLocation, user: str | None, context: str, worker: Worker
+    ) -> None:
         """Adds a worker to the pool of reusable workers."""
         # Free reserved memory.
         self._memory_in_use -= worker.permissions.memory
@@ -243,7 +244,7 @@ class WorkerPool:
             await self._free_memory(worker.permissions.memory)
 
             # Add the worker.
-            identifier = _IdleWorkersIdentifier(package, lms, context)
+            identifier = _IdleWorkersIdentifier(package, user, context)
             self._idle_workers[identifier].appendleft(worker)
             self._oldest_idle_workers.appendleft((worker, identifier))
 

--- a/tests/questionpy_server/worker/impl/test_base.py
+++ b/tests/questionpy_server/worker/impl/test_base.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 
 async def test_should_get_manifest(worker_pool: WorkerPool) -> None:
-    async with worker_pool.get_worker(PACKAGE, 1, "tests", DEFAULT_WORKER_PERMISSIONS) as worker:
+    async with worker_pool.get_worker(PACKAGE, "tester", "tests", DEFAULT_WORKER_PERMISSIONS) as worker:
         manifest = await worker.get_manifest()
         assert manifest == PACKAGE.manifest
 
@@ -41,7 +41,7 @@ async def test_should_get_static_file(
 
     package: PackageLocation = dir_package if package_type == "dir" else package_factory.to_zip_package(dir_package)
 
-    async with worker_pool.get_worker(package, 1, "tests", DEFAULT_WORKER_PERMISSIONS) as worker:
+    async with worker_pool.get_worker(package, "tester", "tests", DEFAULT_WORKER_PERMISSIONS) as worker:
         static_file = await worker.get_static_file(_STATIC_FILE_NAME)
 
     assert static_file.data == _STATIC_FILE_CONTENT.encode()
@@ -58,7 +58,7 @@ async def test_should_raise_file_not_found_error_when_not_in_manifest(
 
     package: PackageLocation = dir_package if package_type == "dir" else package_factory.to_zip_package(dir_package)
 
-    async with worker_pool.get_worker(package, 1, "tests", DEFAULT_WORKER_PERMISSIONS) as worker:
+    async with worker_pool.get_worker(package, "tester", "tests", DEFAULT_WORKER_PERMISSIONS) as worker:
         with pytest.raises(FileNotFoundError):
             await worker.get_static_file(_STATIC_FILE_NAME)
 
@@ -83,7 +83,7 @@ async def test_should_raise_file_not_found_error_when_file_is_outside(
         else package_factory.to_zip_package(dir_package, include_siblings=("my_secret_file",))
     )
 
-    async with worker_pool.get_worker(package, 1, "tests", DEFAULT_WORKER_PERMISSIONS) as worker:
+    async with worker_pool.get_worker(package, "tester", "tests", DEFAULT_WORKER_PERMISSIONS) as worker:
         with caplog.at_level(logging.INFO), pytest.raises(FileNotFoundError):
             await worker.get_static_file("static/../../my_secret_file")
 
@@ -103,7 +103,7 @@ async def test_should_raise_file_not_found_error_when_symlink_target_is_outside(
 
     package.inject_static_file_into_manifest("static/my_secret_file", len(content), "text/plain")
 
-    async with worker_pool.get_worker(package, 1, "tests", DEFAULT_WORKER_PERMISSIONS) as worker:
+    async with worker_pool.get_worker(package, "tester", "tests", DEFAULT_WORKER_PERMISSIONS) as worker:
         with caplog.at_level(logging.INFO), pytest.raises(FileNotFoundError):
             await worker.get_static_file("static/my_secret_file")
 
@@ -119,7 +119,7 @@ async def test_should_raise_file_not_found_error_when_not_on_disk(
 
     package: PackageLocation = dir_package if package_type == "dir" else package_factory.to_zip_package(dir_package)
 
-    async with worker_pool.get_worker(package, 1, "tests", DEFAULT_WORKER_PERMISSIONS) as worker:
+    async with worker_pool.get_worker(package, "tester", "tests", DEFAULT_WORKER_PERMISSIONS) as worker:
         with pytest.raises(FileNotFoundError):
             await worker.get_static_file(_STATIC_FILE_NAME)
 
@@ -134,7 +134,7 @@ async def test_should_raise_static_file_size_mismatch_error_when_sizes_dont_matc
 
     package: PackageLocation = dir_package if package_type == "dir" else package_factory.to_zip_package(dir_package)
 
-    async with worker_pool.get_worker(package, 1, "tests", DEFAULT_WORKER_PERMISSIONS) as worker:
+    async with worker_pool.get_worker(package, "tester", "tests", DEFAULT_WORKER_PERMISSIONS) as worker:
         with pytest.raises(StaticFileSizeMismatchError):
             await worker.get_static_file(_STATIC_FILE_NAME)
 
@@ -163,13 +163,13 @@ def _make_get_manifest_raise() -> Iterator[None]:
 @pytest.mark.filterwarnings("ignore:Exception in thread worker-")
 async def test_should_gracefully_handle_error_in_bootstrap(worker_pool: WorkerPool) -> None:
     with patch_worker_pool(worker_pool, _make_bootstrap_raise), pytest.raises(WorkerStartError):
-        async with worker_pool.get_worker(PACKAGE, 1, "tests", DEFAULT_WORKER_PERMISSIONS):
+        async with worker_pool.get_worker(PACKAGE, "tester", "tests", DEFAULT_WORKER_PERMISSIONS):
             pass
 
 
 async def test_should_gracefully_handle_error_in_loop(worker_pool: WorkerPool) -> None:
     with patch_worker_pool(worker_pool, _make_get_manifest_raise):
-        async with worker_pool.get_worker(PACKAGE, 1, "tests", DEFAULT_WORKER_PERMISSIONS) as worker:
+        async with worker_pool.get_worker(PACKAGE, "tester", "tests", DEFAULT_WORKER_PERMISSIONS) as worker:
             with pytest.raises(WorkerUnknownError, match="some custom error"):
                 await worker.get_manifest()
 

--- a/tests/questionpy_server/worker/impl/test_subprocess.py
+++ b/tests/questionpy_server/worker/impl/test_subprocess.py
@@ -25,7 +25,7 @@ from tests.questionpy_server.worker.impl.conftest import patch_worker_pool
 
 @pytest.mark.parametrize("worker_pool", [SubprocessWorker], indirect=True)
 async def test_should_apply_limits(worker_pool: WorkerPool) -> None:
-    async with worker_pool.get_worker(PACKAGE, 1, "tests", DEFAULT_WORKER_PERMISSIONS) as worker:
+    async with worker_pool.get_worker(PACKAGE, "tester", "tests", DEFAULT_WORKER_PERMISSIONS) as worker:
         assert isinstance(worker, SubprocessWorker)
         assert worker._proc
         # Python's resource package can only get the rlimit of other processes on Linux, so we use psutil.
@@ -52,7 +52,7 @@ async def test_should_raise_cpu_timout_error(worker_pool: WorkerPool) -> None:
         start_time = time()
         # Change the timeout for faster testing.
         with pytest.raises(WorkerStartError) as exc_info, patch.object(BaseWorker, "_init_worker_timeout", 0.05):
-            async with worker_pool.get_worker(PACKAGE, 1, "tests", DEFAULT_WORKER_PERMISSIONS):
+            async with worker_pool.get_worker(PACKAGE, "tester", "tests", DEFAULT_WORKER_PERMISSIONS):
                 pass
         assert isinstance(exc_info.value.__cause__, WorkerCPUTimeLimitExceededError)
         assert 0.05 < (time() - start_time) < 0.5
@@ -79,7 +79,7 @@ async def test_should_raise_real_timout_error(worker_pool: WorkerPool) -> None:
             patch.object(BaseWorker, "_init_worker_timeout", 0.6),
             patch.object(LimitTimeUsageMixin, "_real_time_limit_factor", 1.0),
         ):
-            async with worker_pool.get_worker(PACKAGE, 1, "tests", DEFAULT_WORKER_PERMISSIONS) as worker:
+            async with worker_pool.get_worker(PACKAGE, "tester", "tests", DEFAULT_WORKER_PERMISSIONS) as worker:
                 await worker.get_manifest()
         assert isinstance(exc_info.value.__cause__, WorkerRealTimeLimitExceededError)
         assert 0.6 < (time() - start_time) < 2.0

--- a/tests/questionpy_server/worker/impl/test_thread.py
+++ b/tests/questionpy_server/worker/impl/test_thread.py
@@ -15,7 +15,7 @@ from tests.conftest import DEFAULT_WORKER_PERMISSIONS, PACKAGE
 @pytest.mark.parametrize("worker_pool", [ThreadWorker], indirect=True)
 async def test_should_ignore_limits(worker_pool: WorkerPool) -> None:
     with patch.object(resource, "setrlimit") as mock:
-        async with worker_pool.get_worker(PACKAGE, 1, "tests", DEFAULT_WORKER_PERMISSIONS):
+        async with worker_pool.get_worker(PACKAGE, "tester", "tests", DEFAULT_WORKER_PERMISSIONS):
             pass
 
         mock.assert_not_called()


### PR DESCRIPTION
Basiert auf  #169

>  Neben `request_context` soll es noch `request_user` im `PackageSelector` geben. Damit sollen `WorkerPermissions` auch User-abhängig gemacht werden. Bei mehreren Usern, wird damit `request_context` erst wirklich nützlich.

Zusätzlich wird `WorkerPool.get_worker` auch der User übergeben.