### PR TITLE
feat: make `WorkerPermissions` not nullable

### DIFF
--- a/questionpy_common/environment.py
+++ b/questionpy_common/environment.py
@@ -120,8 +120,8 @@ class Environment(Protocol):
         """
 
     @property
-    def permissions(self) -> WorkerPermissions | None:
-        """The permissions of the worker, if any."""
+    def permissions(self) -> WorkerPermissions:
+        """The permissions of the worker."""
 
     @property
     def request_user(self) -> RequestUser | None:

--- a/questionpy_server/worker/__init__.py
+++ b/questionpy_server/worker/__init__.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import NotRequired, TypedDict, TypeVar, Unpack
+from typing import TypedDict, TypeVar, Unpack
 
 from pydantic import BaseModel
 
@@ -58,7 +58,7 @@ class WorkerArgs(TypedDict):
     """The main package that the worker should load when [start][questionpy_server.worker.Worker.start] is called."""
     worker_home: Path
     """An existing directory owned by the worker, with the same lifetime as the worker."""
-    permissions: NotRequired[WorkerPermissions | None]
+    permissions: WorkerPermissions
     """The worker permissions."""
 
 

--- a/questionpy_server/worker/impl/_base.py
+++ b/questionpy_server/worker/impl/_base.py
@@ -113,7 +113,7 @@ class BaseWorker(Worker, ABC):
         loaded = await self.send_and_wait_for_response(
             LoadQPyPackage(location=package_location, main=main),
             LoadQPyPackage.Response,
-            self.permissions.bootstrap_timeout if self.permissions else 4,
+            self.permissions.bootstrap_timeout,
         )
 
         root_package_hash = package_location.hash if isinstance(package_location, ZipPackageLocation) else None

--- a/questionpy_server/worker/impl/subprocess.py
+++ b/questionpy_server/worker/impl/subprocess.py
@@ -4,7 +4,6 @@
 
 import asyncio
 import logging
-import math
 import re
 import signal
 import sys
@@ -160,7 +159,7 @@ class SubprocessWorker(BaseWorker, LimitTimeUsageMixin):
     ) -> _T:
         try:
             if timeout is None:
-                timeout = self.permissions.request_timeout if self.permissions else math.inf
+                timeout = self.permissions.request_timeout
             self._set_time_limit(timeout)
             return await super().send_and_wait_for_response(message, expected_response_message, timeout)
         finally:

--- a/questionpy_server/worker/impl/thread.py
+++ b/questionpy_server/worker/impl/thread.py
@@ -89,13 +89,6 @@ class ThreadWorker(BaseWorker):
                 self._pipe = None
 
     async def start(self) -> None:
-        if self.permissions:
-            log.warning(
-                "Permissions '%s' were given, but thread-based workers don't support permissions.",
-                self.permissions,
-            )
-            self.permissions = None
-
         self._pipe = DuplexPipe.open()
         thread = _WorkerThread(f"worker-{self.name}", self._pipe)
 

--- a/questionpy_server/worker/pool.py
+++ b/questionpy_server/worker/pool.py
@@ -25,7 +25,6 @@ from questionpy_server.worker.runtime.package_location import (
 )
 
 from . import Worker, WorkerState
-from .impl.thread import ThreadWorker
 
 _log = logging.getLogger(__name__)
 
@@ -35,10 +34,6 @@ class _WorkerPoolMemoryError(QPyBaseError):
 
     def __init__(self) -> None:
         super().__init__("Cannot free the required amount of memory. This is likely a bug.")
-
-
-def _memory_limit_or_zero(permissions: WorkerPermissions | None) -> int:
-    return permissions.memory if permissions else 0
 
 
 class _IdleWorkersIdentifier(NamedTuple):
@@ -169,9 +164,8 @@ class WorkerPool:
         # Stop the worker and free the memory.
         await worker.stop(10)
 
-        max_memory = _memory_limit_or_zero(worker.permissions)
-        self._memory_idle -= max_memory
-        return max_memory
+        self._memory_idle -= worker.permissions.memory
+        return worker.permissions.memory
 
     async def _free_memory(self, required_memory: int) -> None:
         """Stops idle workers until the required amount of memory is available."""
@@ -221,7 +215,7 @@ class WorkerPool:
                 del self._idle_workers[identifier]
             self._oldest_idle_workers.remove((worker, identifier))
 
-            self._memory_idle -= _memory_limit_or_zero(worker.permissions)
+            self._memory_idle -= worker.permissions.memory
         else:
             # We need to create a new worker - free as much memory as needed to start the worker.
             await self._free_memory(permissions.memory)
@@ -234,27 +228,26 @@ class WorkerPool:
             await worker.start()
 
         # Reserve the memory.
-        self._memory_in_use += permissions.memory if self._worker_type is not ThreadWorker else 0
+        self._memory_in_use += permissions.memory
 
         return worker
 
     async def _handle_idle_worker(self, package: PackageLocation, lms: int, context: str, worker: Worker) -> None:
         """Adds a worker to the pool of reusable workers."""
         # Free reserved memory.
-        self._memory_in_use -= _memory_limit_or_zero(worker.permissions)
+        self._memory_in_use -= worker.permissions.memory
 
         # Check if the worker is idling.
         if worker.state == WorkerState.IDLE:
             # Free as much memory as need to store the idle worker.
-            required_memory = _memory_limit_or_zero(worker.permissions)
-            await self._free_memory(required_memory)
+            await self._free_memory(worker.permissions.memory)
 
             # Add the worker.
             identifier = _IdleWorkersIdentifier(package, lms, context)
             self._idle_workers[identifier].appendleft(worker)
             self._oldest_idle_workers.appendleft((worker, identifier))
 
-            self._memory_idle += _memory_limit_or_zero(worker.permissions)
+            self._memory_idle += worker.permissions.memory
         else:
             # We cannot reuse this worker as it is not idling.
             await worker.stop(10)

--- a/questionpy_server/worker/runtime/manager.py
+++ b/questionpy_server/worker/runtime/manager.py
@@ -53,9 +53,9 @@ class EnvironmentImpl(Environment):
     _type: str
     _packages: dict[PackageNamespaceAndShortName, ImportablePackage]
     _on_request_callbacks: list[OnRequestCallback]
+    _permissions: WorkerPermissions
     _main_package: ImportablePackage | None = None
     _request_user: RequestUser | None = None
-    _permissions: WorkerPermissions | None = None
 
     @property
     def type(self) -> str:
@@ -77,7 +77,7 @@ class EnvironmentImpl(Environment):
         return self._request_user
 
     @property
-    def permissions(self) -> WorkerPermissions | None:
+    def permissions(self) -> WorkerPermissions:
         return self._permissions
 
     def register_on_request_callback(self, callback: OnRequestCallback) -> None:
@@ -128,7 +128,7 @@ class WorkerManager:
 
         self._worker_home = init_msg.worker_home
 
-        if init_msg.permissions:
+        if init_msg.worker_type != "thread":
             # Limit memory usage.
             resource.setrlimit(resource.RLIMIT_AS, (init_msg.permissions.memory, init_msg.permissions.memory))
 

--- a/questionpy_server/worker/runtime/messages.py
+++ b/questionpy_server/worker/runtime/messages.py
@@ -88,7 +88,7 @@ class InitWorker(MessageToWorker):
     """Give worker some basic information."""
 
     message_id: ClassVar[MessageIds] = MessageIds.INIT_WORKER
-    permissions: WorkerPermissions | None = None
+    permissions: WorkerPermissions
     worker_type: str
     worker_home: Path
     """The base directory for worker files.


### PR DESCRIPTION
Die Worker und der Worker-Pool können nun immer auf die `WorkerPermissions` zugreifen, selbst wenn diese, wie aktuell beim `ThreadWorker`, nicht angewendet werden.