### PR TITLE
feat: check, send, and provide lms attributes

### DIFF
--- a/questionpy_common/api/question.py
+++ b/questionpy_common/api/question.py
@@ -10,7 +10,14 @@ from pydantic import BaseModel, Field, JsonValue
 from . import Localized
 from .attempt import AttemptModel, AttemptScoredModel, AttemptStartedModel
 
-__all__ = ["PossibleResponse", "QuestionInterface", "QuestionModel", "ScoringMethod", "SubquestionModel"]
+__all__ = [
+    "LmsPermissions",
+    "PossibleResponse",
+    "QuestionInterface",
+    "QuestionModel",
+    "ScoringMethod",
+    "SubquestionModel",
+]
 
 
 class ScoringMethod(Enum):

--- a/questionpy_server/web/__init__.py
+++ b/questionpy_server/web/__init__.py
@@ -1,3 +1,5 @@
 #  This file is part of the QuestionPy Server. (https://questionpy.org)
 #  The QuestionPy Server is free software released under terms of the MIT license. See LICENSE.md.
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
+CURRENT_USER_KEY = "qpy-current-user"

--- a/questionpy_server/web/_routes/_attempts.py
+++ b/questionpy_server/web/_routes/_attempts.py
@@ -1,7 +1,6 @@
 #  This file is part of the QuestionPy Server. (https://questionpy.org)
 #  The QuestionPy Server is free software released under terms of the MIT license. See LICENSE.md.
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
-
 from aiohttp import web
 
 from questionpy_server.models import (
@@ -14,8 +13,8 @@ from questionpy_server.models import (
 )
 from questionpy_server.package import Package
 from questionpy_server.web._decorators import ensure_required_parts
-from questionpy_server.web._utils import CURRENT_USER_KEY, DEFAULT_REQUEST_INFO, pydantic_json_response
-from questionpy_server.web.app import QPyServer
+from questionpy_server.web._utils import pydantic_json_response
+from questionpy_server.web._worker_context import worker_context
 
 attempt_routes = web.RouteTableDef()
 
@@ -25,15 +24,9 @@ attempt_routes = web.RouteTableDef()
 async def post_attempt_start(
     request: web.Request, package: Package, question_state: bytes, data: AttemptStartArguments
 ) -> web.Response:
-    qpyserver = request.app[QPyServer.APP_KEY]
-
-    current_user = request.get(CURRENT_USER_KEY)
-    permissions = qpyserver.package_permissions.get_effective_permissions(package, current_user, data.context)
-    location = await package.get_zip_package_location()
-
-    async with qpyserver.worker_pool.get_worker(location, current_user, data.context, permissions) as worker:
-        attempt = await worker.start_attempt(DEFAULT_REQUEST_INFO, question_state.decode(), data.variant)
-        packages = worker.get_loaded_packages()
+    async with worker_context(request, package, data) as context:
+        attempt = await context.worker.start_attempt(context.request_info, question_state.decode(), data.variant)
+        packages = context.worker.get_loaded_packages()
 
     resp = AttemptStartedResponse(**dict(attempt), package_dependencies=packages)
     return pydantic_json_response(data=resp, status=201)
@@ -44,21 +37,15 @@ async def post_attempt_start(
 async def post_attempt_view(
     request: web.Request, package: Package, question_state: bytes, data: AttemptViewArguments
 ) -> web.Response:
-    qpyserver = request.app[QPyServer.APP_KEY]
-
-    current_user = request.get(CURRENT_USER_KEY)
-    permissions = qpyserver.package_permissions.get_effective_permissions(package, current_user, data.context)
-    location = await package.get_zip_package_location()
-
-    async with qpyserver.worker_pool.get_worker(location, current_user, data.context, permissions) as worker:
-        attempt = await worker.get_attempt(
-            request_info=DEFAULT_REQUEST_INFO,
+    async with worker_context(request, package, data) as context:
+        attempt = await context.worker.get_attempt(
+            request_info=context.request_info,
             question_state=question_state.decode(),
             attempt_state=data.attempt_state,
             scoring_state=data.scoring_state,
             response=data.response,
         )
-        packages = worker.get_loaded_packages()
+        packages = context.worker.get_loaded_packages()
 
     resp = AttemptResponse(**dict(attempt), package_dependencies=packages)
     return pydantic_json_response(data=resp, status=201)
@@ -69,21 +56,15 @@ async def post_attempt_view(
 async def post_attempt_score(
     request: web.Request, package: Package, question_state: bytes, data: AttemptScoreArguments
 ) -> web.Response:
-    qpyserver = request.app[QPyServer.APP_KEY]
-
-    current_user = request.get(CURRENT_USER_KEY)
-    permissions = qpyserver.package_permissions.get_effective_permissions(package, current_user, data.context)
-    location = await package.get_zip_package_location()
-
-    async with qpyserver.worker_pool.get_worker(location, current_user, data.context, permissions) as worker:
-        attempt_scored = await worker.score_attempt(
-            request_info=DEFAULT_REQUEST_INFO,
+    async with worker_context(request, package, data) as context:
+        attempt_scored = await context.worker.score_attempt(
+            request_info=context.request_info,
             question_state=question_state.decode(),
             attempt_state=data.attempt_state,
             scoring_state=data.scoring_state,
             response=data.response,
         )
-        packages = worker.get_loaded_packages()
+        packages = context.worker.get_loaded_packages()
 
     resp = AttemptScoredResponse(**dict(attempt_scored), package_dependencies=packages)
     return pydantic_json_response(data=resp, status=201)

--- a/questionpy_server/web/_routes/_files.py
+++ b/questionpy_server/web/_routes/_files.py
@@ -6,8 +6,8 @@ from aiohttp import web
 from aiohttp.web_exceptions import HTTPNotImplemented
 
 from questionpy_server.package import Package
+from questionpy_server.web import CURRENT_USER_KEY
 from questionpy_server.web._decorators import ensure_package
-from questionpy_server.web._utils import CURRENT_USER_KEY
 from questionpy_server.web.app import QPyServer
 
 file_routes = web.RouteTableDef()

--- a/questionpy_server/web/_routes/_packages.py
+++ b/questionpy_server/web/_routes/_packages.py
@@ -5,10 +5,12 @@
 from aiohttp import web
 from aiohttp.web_exceptions import HTTPMethodNotAllowed
 
+from questionpy_common.api.question import LmsPermissions
 from questionpy_server.models import QuestionCreateArguments, QuestionEditFormResponse, RequestBaseData
 from questionpy_server.package import Package
 from questionpy_server.web._decorators import ensure_package, ensure_required_parts
-from questionpy_server.web._utils import CURRENT_USER_KEY, DEFAULT_REQUEST_INFO, pydantic_json_response
+from questionpy_server.web._utils import pydantic_json_response
+from questionpy_server.web._worker_context import worker_context
 from questionpy_server.web.app import QPyServer
 from questionpy_server.web.errors import PackageNotFoundError
 
@@ -41,17 +43,11 @@ async def post_options(
     request: web.Request, package: Package, data: RequestBaseData, question_state: bytes | None = None
 ) -> web.Response:
     """Get the options form definition that allow a question creator to customize a question."""
-    qpyserver = request.app[QPyServer.APP_KEY]
-
-    current_user = request.get(CURRENT_USER_KEY)
-    permissions = qpyserver.package_permissions.get_effective_permissions(package, current_user, data.context)
-    location = await package.get_zip_package_location()
-
-    async with qpyserver.worker_pool.get_worker(location, current_user, data.context, permissions) as worker:
-        definition, form_data = await worker.get_options_form(
-            DEFAULT_REQUEST_INFO, question_state.decode() if question_state else None
+    async with worker_context(request, package, data) as context:
+        definition, form_data = await context.worker.get_options_form(
+            context.request_info, question_state.decode() if question_state else None
         )
-        packages = worker.get_loaded_packages()
+        packages = context.worker.get_loaded_packages()
 
     return pydantic_json_response(
         data=QuestionEditFormResponse(definition=definition, form_data=form_data, package_dependencies=packages)
@@ -63,15 +59,16 @@ async def post_options(
 async def post_question(
     request: web.Request, package: Package, data: QuestionCreateArguments, question_state: bytes | None = None
 ) -> web.Response:
-    qpyserver = request.app[QPyServer.APP_KEY]
+    async with worker_context(request, package, data) as context:
+        lms_permissions = None
+        if context.permissions.lms_attributes:
+            lms_permissions = LmsPermissions(attributes=context.permissions.lms_attributes)
 
-    current_user = request.get(CURRENT_USER_KEY)
-    permissions = qpyserver.package_permissions.get_effective_permissions(package, current_user, data.context)
-    location = await package.get_zip_package_location()
-
-    async with qpyserver.worker_pool.get_worker(location, current_user, data.context, permissions) as worker:
-        question = await worker.create_question_from_options(
-            DEFAULT_REQUEST_INFO, question_state.decode() if question_state else None, data.form_data
+        question = await context.worker.create_question_from_options(
+            context.request_info,
+            question_state.decode() if question_state else None,
+            data.form_data,
+            lms_permissions,
         )
 
     return pydantic_json_response(data=question)

--- a/questionpy_server/web/_utils.py
+++ b/questionpy_server/web/_utils.py
@@ -13,8 +13,6 @@ from aiohttp.web_exceptions import HTTPRequestEntityTooLarge
 from aiohttp.web_response import Response
 
 from questionpy_common.constants import KiB
-from questionpy_common.environment import RequestInfo
-from questionpy_common.manifest import Bcp47LanguageTag
 from questionpy_server.hash import HashContainer
 
 
@@ -65,11 +63,3 @@ async def read_part(part: BodyPartReader, max_size: int, *, calculate_hash: bool
     if calculate_hash:
         return HashContainer(data=buffer.getvalue(), hash=hash_object.hexdigest())
     return buffer.getvalue()
-
-
-# TODO: Replace with Accept-Language header contents and lms provided attributes.
-DEFAULT_REQUEST_INFO = RequestInfo(
-    lms_provided_attributes=None,
-    preferred_languages=[Bcp47LanguageTag("de"), Bcp47LanguageTag("en")],
-)
-CURRENT_USER_KEY = "qpy-current-user"

--- a/questionpy_server/web/_worker_context.py
+++ b/questionpy_server/web/_worker_context.py
@@ -1,0 +1,51 @@
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import NamedTuple
+
+from aiohttp import web
+
+from questionpy_common.environment import LmsProvidedAttributes, PackagePermissions, RequestInfo
+from questionpy_common.manifest import Bcp47LanguageTag
+from questionpy_server.models import LmsProvidedAttributes as LmsProvidedAttributesModel
+from questionpy_server.models import RequestBaseData
+from questionpy_server.package import Package
+from questionpy_server.web import CURRENT_USER_KEY
+from questionpy_server.web.app import QPyServer
+from questionpy_server.worker import Worker
+
+
+def get_request_info(
+    _request: web.Request, *, lms_provided_attributes: LmsProvidedAttributes | None = None
+) -> RequestInfo:
+    """Retrieves the [RequestInfo][] object for the given request."""
+    return RequestInfo(
+        lms_provided_attributes=lms_provided_attributes,
+        # TODO: Replace with Accept-Language header contents.
+        preferred_languages=[Bcp47LanguageTag("de"), Bcp47LanguageTag("en")],
+    )
+
+
+class WorkerContext(NamedTuple):
+    worker: Worker
+    request_info: RequestInfo
+    permissions: PackagePermissions
+
+
+@asynccontextmanager
+async def worker_context(request: web.Request, package: Package, data: RequestBaseData) -> AsyncIterator[WorkerContext]:
+    """Returns the worker context for the given request."""
+    qpyserver = request.app[QPyServer.APP_KEY]
+    current_user = request.get(CURRENT_USER_KEY)
+    permissions = qpyserver.package_permissions.get_effective_permissions(package, current_user, data.context)
+    location = await package.get_zip_package_location()
+
+    lms_provided_attributes = None
+    if isinstance(data, LmsProvidedAttributesModel):
+        lms_provided_attributes = data.lms_provided_attributes
+
+    async with qpyserver.worker_pool.get_worker(location, current_user, data.context, permissions) as worker:
+        yield WorkerContext(
+            worker,
+            get_request_info(request, lms_provided_attributes=lms_provided_attributes),
+            permissions,
+        )

--- a/questionpy_server/web/middlewares/_authentication.py
+++ b/questionpy_server/web/middlewares/_authentication.py
@@ -10,7 +10,7 @@ from aiohttp.web_request import Request
 from aiohttp.web_response import StreamResponse
 
 from questionpy_server.settings import AuthSettings
-from questionpy_server.web._utils import CURRENT_USER_KEY
+from questionpy_server.web import CURRENT_USER_KEY
 
 PASSWORD_ENCODING = "utf-8"  # noqa: S105
 

--- a/questionpy_server/worker/__init__.py
+++ b/questionpy_server/worker/__init__.py
@@ -10,6 +10,7 @@ from typing import TypedDict, TypeVar, Unpack
 from pydantic import BaseModel
 
 from questionpy_common.api.attempt import AttemptModel, AttemptScoredModel, AttemptStartedModel
+from questionpy_common.api.question import LmsPermissions
 from questionpy_common.elements import OptionsFormDefinition
 from questionpy_common.environment import PackagePermissions, RequestInfo
 from questionpy_common.manifest import PackageFile
@@ -129,7 +130,11 @@ class Worker(ABC):
 
     @abstractmethod
     async def create_question_from_options(
-        self, request_info: RequestInfo, old_state: str | None, form_data: dict[str, object]
+        self,
+        request_info: RequestInfo,
+        old_state: str | None,
+        form_data: dict[str, object],
+        lms_permissions: LmsPermissions | None,
     ) -> QuestionCreated:
         """Create or update the question (state) with the form data from a submitted question edit form.
 
@@ -137,6 +142,7 @@ class Worker(ABC):
             request_info: Information about the current request.
             old_state: The current question state if editing, or ``None`` if creating a new question.
             form_data: Form data from a submitted question edit form.
+            lms_permissions: LMS permissions requested by the package and granted by the server.
 
         Returns:
             New question.

--- a/questionpy_server/worker/impl/_base.py
+++ b/questionpy_server/worker/impl/_base.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Unpack
 from zipfile import ZipFile
 
 from questionpy_common.api.attempt import AttemptModel, AttemptScoredModel, AttemptStartedModel
+from questionpy_common.api.question import LmsPermissions
 from questionpy_common.constants import DIST_DIR
 from questionpy_common.elements import OptionsFormDefinition
 from questionpy_common.environment import RequestInfo
@@ -236,12 +237,18 @@ class BaseWorker(Worker, ABC):
         return ret.definition, ret.form_data
 
     async def create_question_from_options(
-        self, request_info: RequestInfo, old_state: str | None, form_data: dict[str, object]
+        self,
+        request_info: RequestInfo,
+        old_state: str | None,
+        form_data: dict[str, object],
+        lms_permissions: LmsPermissions | None,
     ) -> QuestionCreated:
         msg = CreateQuestionFromOptions(question_state=old_state, form_data=form_data, request_info=request_info)
         ret = await self.send_and_wait_for_response(msg, CreateQuestionFromOptions.Response)
 
-        return QuestionCreated(question_state=ret.question_state, **ret.question_model.model_dump())
+        return QuestionCreated(
+            question_state=ret.question_state, lms_permissions=lms_permissions, **ret.question_model.model_dump()
+        )
 
     async def start_attempt(self, request_info: RequestInfo, question_state: str, variant: int) -> AttemptStartedModel:
         msg = StartAttempt(question_state=question_state, variant=variant, request_info=request_info)

--- a/questionpy_server/worker/permissions.py
+++ b/questionpy_server/worker/permissions.py
@@ -77,7 +77,7 @@ class PackagePermissionsHandler:
         requested_permissions = package.manifest.permissions
         if requested_permissions is None:
             # If the package requests no permissions, we use the default ones.
-            actual_permissions = self._default_permissions
+            actual_permissions = self._default_permissions.model_copy()
         else:
             if requested_modes := requested_permissions.main_process_execution_modes:
                 if intersection := requested_modes.intersection(MainProcessExecutionModeValues):
@@ -138,6 +138,9 @@ class PackagePermissionsHandler:
         if not _has_enough_permissions(auto_grant_permissions, requested_permissions):
             msg = f"The package '{package.hash}' requested more permissions than allowed."
             raise PackagePermissionError(msg)
+
+        # Only keep explicitly allowed lms attributes.
+        requested_permissions.lms_attributes.intersection_update(auto_grant_permissions.lms_attributes)
 
         effective_permissions = EnvironmentPackagePermissions(**requested_permissions.model_dump())
         self._cache.put(key, effective_permissions)


### PR DESCRIPTION
Closes #180

Auf die vom LMS gesendeten Attribute kann über `get_qpy_environment()` -> `Environment.request_info` -> `RequestInfo.lms_provided_attributes` zugegriffen werden.

Anmerkung zum `worker_context`-Context-Manager: Leider inferred PyCharm die Typen beim Entpacken des `RequestContext` nicht (https://youtrack.jetbrains.com/projects/PY/issues/PY-82478/PyCharm-doesnt-infer-the-unpacked-type-of-NamedTuple-if-it-is-returned-from-a-function), weshalb ich mit `context.<attribute>` arbeite.