### PR TITLE
fix: `TypeError`

### DIFF
--- a/docs/qppe-server.yaml
+++ b/docs/qppe-server.yaml
@@ -763,6 +763,16 @@ components:
                           format: double
                       required: [ response_class, score ]
                 required: [ subquestion_id, score_max, response_classes ]
+          required: [ scoring_method ]
+
+    QuestionCreated:
+      allOf:
+        - $ref: '#/components/schemas/Question'
+        - type: object
+          properties:
+            question_state:
+              type: string
+              description: Arbitrary values set by the question package code (LMS must store this data unmodified)
             lms_permissions:
               type: object
               nullable: true
@@ -776,16 +786,6 @@ components:
                   example: [ attempt_id, group_id, user_id ]
                   items:
                     type: string
-          required: [ scoring_method ]
-
-    QuestionCreated:
-      allOf:
-        - $ref: '#/components/schemas/Question'
-        - type: object
-          properties:
-            question_state:
-              type: string
-              description: Arbitrary values set by the question package code (LMS must store this data unmodified)
           required: [ question_state ]
 
     Attributes:

--- a/questionpy_common/api/question.py
+++ b/questionpy_common/api/question.py
@@ -52,8 +52,6 @@ class QuestionModel(Localized):
     random_guess_score: float | None = None
     response_analysis_by_variant: bool = False
 
-    lms_permissions: LmsPermissions | None = None
-
     subquestions: list[SubquestionModel] = []
 
 

--- a/questionpy_server/models.py
+++ b/questionpy_server/models.py
@@ -8,7 +8,7 @@ from typing import Annotated, Any
 from pydantic import BaseModel, ByteSize, ConfigDict, Field
 
 from questionpy_common.api.attempt import AttemptModel, AttemptScoredModel, AttemptStartedModel
-from questionpy_common.api.question import QuestionModel
+from questionpy_common.api.question import LmsPermissions, QuestionModel
 from questionpy_common.elements import OptionsFormDefinition
 from questionpy_common.environment import LmsProvidedAttributes as EnvironmentLmsProvidedAttributes
 from questionpy_common.manifest import Bcp47LanguageTag, PackageType
@@ -80,6 +80,7 @@ class QuestionCreateArguments(RequestBaseData):
 
 
 class QuestionCreated(QuestionModel):
+    lms_permissions: LmsPermissions | None = None
     question_state: str
 
 


### PR DESCRIPTION
`question_model` hat das Attribut `lms_permissions`, wodurch es beim Entpacken von `ret.question_model.model_dump()` zu einem `TypeError`  gekommen ist: `got multiple values for keyword argument 'lms_permissions'`.